### PR TITLE
[NO-TASK] Fix CORS error with empty query strings

### DIFF
--- a/packages/react/src/hooks/payment-routes.hook.ts
+++ b/packages/react/src/hooks/payment-routes.hook.ts
@@ -74,7 +74,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId, externalPaymentId });
 
     return call<PaymentLink | PaymentLink[]>({
-      url: `${PaymentLinksUrl.get}?${queryParams}`,
+      url: queryParams ? `${PaymentLinksUrl.get}?${queryParams}` : PaymentLinksUrl.get,
       method: 'GET',
     });
   }
@@ -96,7 +96,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId, externalPaymentId });
 
     return call<PaymentLink>({
-      url: `${PaymentLinksUrl.update}?${queryParams}`,
+      url: queryParams ? `${PaymentLinksUrl.update}?${queryParams}` : PaymentLinksUrl.update,
       method: 'PUT',
       data: request,
     });
@@ -110,7 +110,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId });
 
     return call<PaymentLink>({
-      url: `${PaymentLinksUrl.assign}?${queryParams}`,
+      url: queryParams ? `${PaymentLinksUrl.assign}?${queryParams}` : PaymentLinksUrl.assign,
       method: 'PUT',
       data: request,
     });
@@ -136,7 +136,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId });
 
     return call<PaymentLink>({
-      url: `${PaymentLinksUrl.payment}?${queryParams}`,
+      url: queryParams ? `${PaymentLinksUrl.payment}?${queryParams}` : PaymentLinksUrl.payment,
       method: 'POST',
       data: request,
     });
@@ -150,7 +150,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId, externalPaymentId });
 
     return call<PaymentLink>({
-      url: `${PaymentLinksUrl.payment}?${queryParams}`,
+      url: queryParams ? `${PaymentLinksUrl.payment}?${queryParams}` : PaymentLinksUrl.payment,
       method: 'DELETE',
     });
   }
@@ -166,7 +166,7 @@ export function usePaymentRoutes(): PaymentRoutesInterface {
   ): Promise<PaymentLinkPos> {
     const queryParams = Utils.buildQueryParams({ linkId, externalLinkId, externalPaymentId });
 
-    return call<PaymentLinkPos>({ url: `${PaymentLinksUrl.pos}?${queryParams}`, method: 'PUT' });
+    return call<PaymentLinkPos>({ url: queryParams ? `${PaymentLinksUrl.pos}?${queryParams}` : PaymentLinksUrl.pos, method: 'PUT' });
   }
 
   async function getPaymentRecipient(route: string): Promise<Sell> {


### PR DESCRIPTION
## Summary
- Fixed CORS error that occurred when API URLs were created with empty query strings
- The bug appeared when accessing routes like https://dev.app.dfx.swiss/routes with LNURL parameters

## Changes
- Modified 6 functions in payment-routes.hook.ts to check if queryParams exists before appending '?' to URLs
- Prevents API calls like `/v1/paymentLink?` (with empty query string) that cause CORS policy violations

## Test plan
- [x] Build passes locally
- [ ] Test payment routes functionality
- [ ] Verify CORS errors no longer occur when accessing routes with LNURL parameters

Co-Authored-By: davidleoMay <141653892+davidleoMay@users.noreply.github.com>