### PR TITLE
Add isPersonalIban flag to Buy interface

### DIFF
--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -43,6 +43,7 @@ export interface Buy {
   paymentLink?: string;
   isValid: boolean;
   error?: TransactionError;
+  isPersonalIban?: boolean;
 }
 
 export interface BuyPaymentInfo {


### PR DESCRIPTION
## Summary
- Add optional `isPersonalIban` field to `Buy` interface to indicate if payment uses a personal IBAN

## Test plan
- Verify the field is correctly exposed from the API
- Used by services to conditionally hide the personal IBAN teaser