### PR TITLE
Add UserProfile type and getProfile hook

### DIFF
--- a/packages/react/src/definitions/user.ts
+++ b/packages/react/src/definitions/user.ts
@@ -1,4 +1,5 @@
 import { Blockchain } from './blockchain';
+import { Country } from './country';
 import { Fiat } from './fiat';
 import { AccountType, TradingLimit } from './kyc';
 import { Language } from './language';
@@ -16,6 +17,7 @@ export const UserUrl = {
   apiFilter: 'user/apiFilter',
   changeAddress: 'user/change',
   specialCodes: 'user/specialCodes',
+  profile: 'user/profile',
 };
 
 export enum UserStatus {
@@ -95,4 +97,23 @@ export interface UpdateUser {
 export interface ApiKey {
   key: string;
   secret: string;
+}
+
+export interface UserAddressInfo {
+  street?: string;
+  houseNumber?: string;
+  city?: string;
+  zip?: string;
+  country?: Country;
+}
+
+export interface UserProfile {
+  accountType?: AccountType;
+  firstName?: string;
+  lastName?: string;
+  mail?: string;
+  phone?: string;
+  address?: UserAddressInfo;
+  organizationName?: string;
+  organizationAddress?: UserAddressInfo;
 }

--- a/packages/react/src/hooks/user.hook.ts
+++ b/packages/react/src/hooks/user.hook.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { ApiKey, Referral, UpdateUser, User, UserUrl } from '../definitions/user';
+import { ApiKey, Referral, UpdateUser, User, UserProfile, UserUrl } from '../definitions/user';
 import { useApi } from './api.hook';
 import { SignIn } from '../definitions/auth';
 import { TransactionFilter, TransactionFilterKey } from '../definitions/transaction';
@@ -7,6 +7,7 @@ import { TransactionFilter, TransactionFilterKey } from '../definitions/transact
 export interface UserInterface {
   getUser: () => Promise<User | undefined>;
   getRef: () => Promise<Referral | undefined>;
+  getProfile: () => Promise<UserProfile | undefined>;
   updateUser: (user?: Partial<User>, userLinkAction?: () => void) => Promise<User | undefined>;
   updateMail: (mail: string) => Promise<void>;
   verifyMail: (token: string) => Promise<User>;
@@ -29,6 +30,10 @@ export function useUser(): UserInterface {
 
   async function getRef(): Promise<Referral | undefined> {
     return call<Referral>({ url: UserUrl.ref, version: 'v2', method: 'GET' });
+  }
+
+  async function getProfile(): Promise<UserProfile | undefined> {
+    return call<UserProfile>({ url: UserUrl.profile, version: 'v2', method: 'GET' });
   }
 
   async function updateUser(updateUser?: UpdateUser, userLinkAction?: () => void): Promise<User | undefined> {
@@ -118,6 +123,7 @@ export function useUser(): UserInterface {
     () => ({
       getUser,
       getRef,
+      getProfile,
       updateUser,
       updateMail,
       verifyMail,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -148,6 +148,8 @@ export {
   Referral,
   Volumes,
   VolumeInformation,
+  UserProfile,
+  UserAddressInfo,
 } from './definitions/user';
 export { SignIn, LnurlAuth, LnurlAuthStatus } from './definitions/auth';
 export {


### PR DESCRIPTION
## Summary
- Add UserProfile and UserAddressInfo interfaces for profile data
- Add getProfile() method to useUser hook
- Export new types from package index

## Changes
- Extended `user.ts` with UserProfile and UserAddressInfo interfaces
- Added getProfile() to user.hook.ts
- Updated index.ts exports

## Dependencies
**This PR requires the API PR to be merged first:**
- API: https://github.com/DFXswiss/api/pull/2637

## Test plan
- [ ] Not yet tested - needs manual verification after API merge