### PR TITLE
Display user profile on account screen

### DIFF
--- a/packages/react/src/definitions/user.ts
+++ b/packages/react/src/definitions/user.ts
@@ -107,11 +107,6 @@ export interface UserAddressInfo {
   country?: Country;
 }
 
-export interface UserOrganization {
-  name?: string;
-  address?: UserAddressInfo;
-}
-
 export interface UserProfile {
   accountType?: AccountType;
   firstName?: string;
@@ -119,5 +114,5 @@ export interface UserProfile {
   mail?: string;
   phone?: string;
   address?: UserAddressInfo;
-  organization?: UserOrganization;
+  organizationName?: string;
 }

--- a/packages/react/src/definitions/user.ts
+++ b/packages/react/src/definitions/user.ts
@@ -107,6 +107,11 @@ export interface UserAddressInfo {
   country?: Country;
 }
 
+export interface UserOrganization {
+  name?: string;
+  address?: UserAddressInfo;
+}
+
 export interface UserProfile {
   accountType?: AccountType;
   firstName?: string;
@@ -114,6 +119,5 @@ export interface UserProfile {
   mail?: string;
   phone?: string;
   address?: UserAddressInfo;
-  organizationName?: string;
-  organizationAddress?: UserAddressInfo;
+  organization?: UserOrganization;
 }

--- a/packages/react/src/definitions/user.ts
+++ b/packages/react/src/definitions/user.ts
@@ -1,4 +1,5 @@
 import { Blockchain } from './blockchain';
+import { Country } from './country';
 import { Fiat } from './fiat';
 import { AccountType, TradingLimit } from './kyc';
 import { Language } from './language';
@@ -16,6 +17,7 @@ export const UserUrl = {
   apiFilter: 'user/apiFilter',
   changeAddress: 'user/change',
   specialCodes: 'user/specialCodes',
+  profile: 'user/profile',
 };
 
 export enum UserStatus {
@@ -95,4 +97,23 @@ export interface UpdateUser {
 export interface ApiKey {
   key: string;
   secret: string;
+}
+
+export interface UserAddressInfo {
+  street?: string;
+  houseNumber?: string;
+  city?: string;
+  zip?: string;
+  country?: Country;
+}
+
+export interface UserProfile {
+  accountType?: AccountType;
+  firstName?: string;
+  lastName?: string;
+  mail?: string;
+  phone?: string;
+  address?: UserAddressInfo;
+  organizationName?: string;
+  organizationAddress?: UserAddressInfo;
 }

--- a/packages/react/src/hooks/user.hook.ts
+++ b/packages/react/src/hooks/user.hook.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { ApiKey, Referral, UpdateUser, User, UserUrl } from '../definitions/user';
+import { ApiKey, Referral, UpdateUser, User, UserProfile, UserUrl } from '../definitions/user';
 import { useApi } from './api.hook';
 import { SignIn } from '../definitions/auth';
 import { TransactionFilter, TransactionFilterKey } from '../definitions/transaction';
@@ -7,6 +7,7 @@ import { TransactionFilter, TransactionFilterKey } from '../definitions/transact
 export interface UserInterface {
   getUser: () => Promise<User | undefined>;
   getRef: () => Promise<Referral | undefined>;
+  getProfile: () => Promise<UserProfile | undefined>;
   updateUser: (user?: Partial<User>, userLinkAction?: () => void) => Promise<User | undefined>;
   updateMail: (mail: string) => Promise<void>;
   verifyMail: (token: string) => Promise<User>;
@@ -29,6 +30,10 @@ export function useUser(): UserInterface {
 
   async function getRef(): Promise<Referral | undefined> {
     return call<Referral>({ url: UserUrl.ref, version: 'v2', method: 'GET' });
+  }
+
+  async function getProfile(): Promise<UserProfile | undefined> {
+    return call<UserProfile>({ url: UserUrl.profile, version: 'v2', method: 'GET' });
   }
 
   async function updateUser(updateUser?: UpdateUser, userLinkAction?: () => void): Promise<User | undefined> {
@@ -118,6 +123,7 @@ export function useUser(): UserInterface {
     () => ({
       getUser,
       getRef,
+      getProfile,
       updateUser,
       updateMail,
       verifyMail,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -150,6 +150,7 @@ export {
   VolumeInformation,
   UserProfile,
   UserAddressInfo,
+  UserOrganization,
 } from './definitions/user';
 export { SignIn, LnurlAuth, LnurlAuthStatus } from './definitions/auth';
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -150,7 +150,6 @@ export {
   VolumeInformation,
   UserProfile,
   UserAddressInfo,
-  UserOrganization,
 } from './definitions/user';
 export { SignIn, LnurlAuth, LnurlAuthStatus } from './definitions/auth';
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -148,6 +148,8 @@ export {
   Referral,
   Volumes,
   VolumeInformation,
+  UserProfile,
+  UserAddressInfo,
 } from './definitions/user';
 export { SignIn, LnurlAuth, LnurlAuthStatus } from './definitions/auth';
 export {


### PR DESCRIPTION
## Summary
- Show user profile information (email, name, address) on /account page
- Add Profile section with KYC data when available
- Add translations for DE, FR, IT

## Changes
- Updated `account.screen.tsx` with profile data display
- Added translations: Profile, Email, Name, Address, Organization

## Dependencies
**These PRs must be merged first (in order):**
1. API: https://github.com/DFXswiss/api/pull/2637
2. Packages: https://github.com/DFXswiss/packages/pull/103

**Do not merge this PR until the API and packages PRs are merged and a new packages version is published.**

## Test plan
- [ ] Not yet tested - needs manual verification
- [ ] Verify profile section appears with correct data
- [ ] Test translations in DE, FR, IT
- [ ] Test with user without KYC (section should not appear)