### PR TITLE
Add bank account fields to TransactionRefundData

### DIFF
--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -195,6 +195,14 @@ export interface TransactionRefundData {
   refundAsset: Asset | Fiat;
   inputAmount: number;
   inputAsset: Asset | Fiat;
+  name?: string;
+  address?: string;
+  houseNumber?: string;
+  zip?: string;
+  city?: string;
+  country?: string;
+  iban?: string;
+  bic?: string;
 }
 
 export interface TransactionHistoryQuery {

--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -188,13 +188,7 @@ export interface RefundFeeData {
   bank: number;
 }
 
-export interface TransactionRefundData {
-  expiryDate: Date;
-  fee: RefundFeeData;
-  refundAmount: number;
-  refundAsset: Asset | Fiat;
-  inputAmount: number;
-  inputAsset: Asset | Fiat;
+export interface RefundBankDetails {
   name?: string;
   address?: string;
   houseNumber?: string;
@@ -203,6 +197,17 @@ export interface TransactionRefundData {
   country?: string;
   iban?: string;
   bic?: string;
+}
+
+export interface TransactionRefundData {
+  expiryDate: Date;
+  fee: RefundFeeData;
+  refundAmount: number;
+  refundAsset: Asset | Fiat;
+  inputAmount: number;
+  inputAsset: Asset | Fiat;
+  refundTarget?: string;
+  bankDetails?: RefundBankDetails;
 }
 
 export interface TransactionHistoryQuery {


### PR DESCRIPTION
## Summary
- Add optional bank account fields to `TransactionRefundData` interface
- Fields: name, address, houseNumber, zip, city, country, iban, bic
- Used to display refund recipient details on the refund page

## Related PRs
- services: feature/refund-bank-details
- api: feature/refund-bank-details