### PR TITLE
Make remittanceInfo optional in Buy interface

### DIFF
--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -24,7 +24,7 @@ export interface Buy {
   bic: string;
   sepaInstant: boolean;
   routeId: number;
-  remittanceInfo: string;
+  remittanceInfo?: string;
   fees: Fees;
   minVolume: number;
   maxVolume: number;


### PR DESCRIPTION
## Summary
- Make `remittanceInfo` optional (`remittanceInfo?: string`) in `Buy` interface
- For buy-specific IBANs, no reference is required as the IBAN is unique to the asset

## Related
- API PR: https://github.com/DFXswiss/api/pull/2685
- Services PR: https://github.com/DFXswiss/services/pull/789