### PR TITLE
Add EIP-7702 delegation support for Sell and Swap

### DIFF
--- a/packages/react/src/definitions/sell.ts
+++ b/packages/react/src/definitions/sell.ts
@@ -5,7 +5,45 @@ import { Fiat } from './fiat';
 import { PriceStep } from './price-step';
 import { TransactionError } from './transaction';
 
-export const SellUrl = { receive: 'sell/paymentInfos' };
+export const SellUrl = {
+  receive: 'sell/paymentInfos',
+  confirm: 'sell/paymentInfos/:id/confirm'
+};
+
+export interface Eip7702DelegationData {
+  relayerAddress: string;
+  delegationManagerAddress: string;
+  delegatorAddress: string;
+  domain: {
+    name: string;
+    version: string;
+    chainId: number;
+    verifyingContract: string;
+  };
+  types: {
+    Delegation: Array<{ name: string; type: string }>;
+    Caveat: Array<{ name: string; type: string }>;
+  };
+  message: {
+    delegate: string;
+    delegator: string;
+    authority: string;
+    caveats: any[];
+    salt: string;
+  };
+}
+
+export interface UnsignedTx {
+  chainId: number;
+  from: string;
+  to: string;
+  data: string;
+  value: string;
+  nonce: number;
+  gasPrice: string;
+  gasLimit: string;
+  eip7702?: Eip7702DelegationData;
+}
 
 export interface Sell {
   id: number;
@@ -30,6 +68,7 @@ export interface Sell {
   currency: Fiat;
   beneficiary: Beneficiary;
   paymentRequest?: string;
+  depositTx?: UnsignedTx;
   isValid: boolean;
   error?: TransactionError;
 }
@@ -47,4 +86,29 @@ export interface SellPaymentInfo {
   targetAmount?: number;
   externalTransactionId?: string;
   exactPrice?: boolean;
+}
+
+export interface Eip7702Authorization {
+  chainId: number | string;
+  address: string;
+  nonce: number | string;
+  r: string;
+  s: string;
+  yParity: number;
+}
+
+export interface Eip7702SignedData {
+  delegation: {
+    delegate: string;
+    delegator: string;
+    authority: string;
+    salt: string;
+    signature: string;
+  };
+  authorization: Eip7702Authorization;
+}
+
+export interface ConfirmSellData {
+  signedTxHex?: string;
+  eip7702?: Eip7702SignedData;
 }

--- a/packages/react/src/definitions/swap.ts
+++ b/packages/react/src/definitions/swap.ts
@@ -1,9 +1,13 @@
 import { Asset } from './asset';
 import { Fees } from './fees';
 import { PriceStep } from './price-step';
+import { Eip7702DelegationData, UnsignedTx, Eip7702SignedData } from './sell';
 import { TransactionError } from './transaction';
 
-export const SwapUrl = { receive: 'swap/paymentInfos' };
+export const SwapUrl = {
+  receive: 'swap/paymentInfos',
+  confirm: 'swap/paymentInfos/:id/confirm'
+};
 
 export interface Swap {
   id: number;
@@ -26,6 +30,7 @@ export interface Swap {
   exactPrice: boolean;
   estimatedAmount: number;
   paymentRequest?: string;
+  depositTx?: UnsignedTx;
   isValid: boolean;
   error?: TransactionError;
 }
@@ -38,4 +43,9 @@ export interface SwapPaymentInfo {
   receiverAddress?: string;
   externalTransactionId?: string;
   exactPrice?: boolean;
+}
+
+export interface ConfirmSwapData {
+  signedTxHex?: string;
+  eip7702?: Eip7702SignedData;
 }

--- a/packages/react/src/hooks/sell.hook.ts
+++ b/packages/react/src/hooks/sell.hook.ts
@@ -1,11 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import { useFiatContext } from '../contexts/fiat.context';
 import { Fiat } from '../definitions/fiat';
-import { Sell, SellPaymentInfo, SellUrl } from '../definitions/sell';
+import { Sell, SellPaymentInfo, SellUrl, ConfirmSellData } from '../definitions/sell';
 import { useApi } from './api.hook';
 
 export interface SellInterface {
   receiveFor: (info: SellPaymentInfo) => Promise<Sell>;
+  confirmSell: (id: number, data: ConfirmSellData) => Promise<void>;
   currencies?: Fiat[];
 }
 
@@ -20,8 +21,12 @@ export function useSell(): SellInterface {
     [call],
   );
 
+  async function confirmSell(id: number, data: ConfirmSellData): Promise<void> {
+    return call<void>({ url: SellUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
+  }
+
   return useMemo(
-    () => ({ receiveFor, currencies: currencies?.filter((c) => c.buyable || c.cardBuyable || c.instantBuyable) }),
-    [receiveFor, currencies],
+    () => ({ receiveFor, confirmSell, currencies: currencies?.filter((c) => c.buyable || c.cardBuyable || c.instantBuyable) }),
+    [receiveFor, confirmSell, currencies],
   );
 }

--- a/packages/react/src/hooks/sell.hook.ts
+++ b/packages/react/src/hooks/sell.hook.ts
@@ -21,9 +21,12 @@ export function useSell(): SellInterface {
     [call],
   );
 
-  async function confirmSell(id: number, data: ConfirmSellData): Promise<void> {
-    return call<void>({ url: SellUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
-  }
+  const confirmSell = useCallback(
+    async (id: number, data: ConfirmSellData): Promise<void> => {
+      return call<void>({ url: SellUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
+    },
+    [call],
+  );
 
   return useMemo(
     () => ({ receiveFor, confirmSell, currencies: currencies?.filter((c) => c.buyable || c.cardBuyable || c.instantBuyable) }),

--- a/packages/react/src/hooks/swap.hook.ts
+++ b/packages/react/src/hooks/swap.hook.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { CallConfig, useApi } from './api.hook';
-import { Swap, SwapPaymentInfo, SwapUrl } from '../definitions/swap';
+import { Swap, SwapPaymentInfo, SwapUrl, ConfirmSwapData } from '../definitions/swap';
 import { useUser } from './user.hook';
 import { useUserContext } from '../contexts/user.context';
 import { ApiError } from '../definitions/error';
@@ -8,6 +8,7 @@ import { useSessionContext } from '../contexts/session.context';
 
 export interface SwapInterface {
   receiveFor: (info: SwapPaymentInfo) => Promise<Swap>;
+  confirmSwap: (id: number, data: ConfirmSwapData) => Promise<void>;
 }
 
 export function useSwap(): SwapInterface {
@@ -40,5 +41,12 @@ export function useSwap(): SwapInterface {
     [call, changeUserAddress, tokenStore, user?.activeAddress?.address],
   );
 
-  return useMemo(() => ({ receiveFor }), [receiveFor]);
+  const confirmSwap = useCallback(
+    async (id: number, data: ConfirmSwapData): Promise<void> => {
+      return call<void>({ url: SwapUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
+    },
+    [call],
+  );
+
+  return useMemo(() => ({ receiveFor, confirmSwap }), [receiveFor, confirmSwap]);
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -136,7 +136,7 @@ export {
   GoodsCategory,
   isStepDone,
 } from './definitions/kyc';
-export { Sell, SellPaymentInfo, Beneficiary } from './definitions/sell';
+export { Sell, SellPaymentInfo, Beneficiary, UnsignedTx, Eip7702DelegationData, Eip7702SignedData, Eip7702Authorization } from './definitions/sell';
 export { Swap, SwapPaymentInfo } from './definitions/swap';
 export { Session } from './definitions/session';
 export {


### PR DESCRIPTION
## Summary
Implements EIP-7702 delegation support for Sell and Swap transactions, enabling gasless token transfers for users with zero native balance on supported EVM chains.

## Changes
- Added new TypeScript interfaces for EIP-7702 delegation data
- Extended Sell and Swap interfaces with optional `depositTx` field
- Implemented `confirmSell()` and `confirmSwap()` methods in hooks
- Exported new types from index for external usage

## Technical Details
- `UnsignedTx`: Contains transaction data and optional EIP-7702 delegation info
- `Eip7702DelegationData`: Domain, types, and message for EIP-712 signature
- `Eip7702SignedData`: Signed delegation and authorization data
- `ConfirmSellData` / `ConfirmSwapData`: Union types for different confirmation methods

## Supported Chains
- Ethereum
- Polygon
- Arbitrum
- Base

## Testing
Backend implementation is ready in the API. Frontend Services integration pending.