### PR TITLE
Export ConfirmSellData and ConfirmSwapData interfaces

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -136,8 +136,8 @@ export {
   GoodsCategory,
   isStepDone,
 } from './definitions/kyc';
-export { Sell, SellPaymentInfo, Beneficiary, UnsignedTx, Eip7702DelegationData, Eip7702SignedData, Eip7702Authorization } from './definitions/sell';
-export { Swap, SwapPaymentInfo } from './definitions/swap';
+export { Sell, SellPaymentInfo, Beneficiary, UnsignedTx, Eip7702DelegationData, Eip7702SignedData, Eip7702Authorization, ConfirmSellData } from './definitions/sell';
+export { Swap, SwapPaymentInfo, ConfirmSwapData } from './definitions/swap';
 export { Session } from './definitions/session';
 export {
   User,


### PR DESCRIPTION
Exports the missing ConfirmSellData and ConfirmSwapData interfaces that are needed for the EIP-7702 delegation implementation.