### PR TITLE
Add includeTx parameter to enable EIP-7702 delegation for Sell and Swap

### DIFF
--- a/packages/react/src/hooks/sell.hook.ts
+++ b/packages/react/src/hooks/sell.hook.ts
@@ -16,7 +16,7 @@ export function useSell(): SellInterface {
 
   const receiveFor = useCallback(
     async (info: SellPaymentInfo): Promise<Sell> => {
-      return call<Sell>({ url: SellUrl.receive, method: 'PUT', data: info });
+      return call<Sell>({ url: `${SellUrl.receive}?includeTx=true`, method: 'PUT', data: info });
     },
     [call],
   );

--- a/packages/react/src/hooks/swap.hook.ts
+++ b/packages/react/src/hooks/swap.hook.ts
@@ -19,7 +19,7 @@ export function useSwap(): SwapInterface {
 
   const receiveFor = useCallback(
     async (info: SwapPaymentInfo): Promise<Swap> => {
-      const request = { url: SwapUrl.receive, method: 'PUT', data: info } as CallConfig;
+      const request = { url: `${SwapUrl.receive}?includeTx=true`, method: 'PUT', data: info } as CallConfig;
       const { receiverAddress } = info;
 
       if (receiverAddress && user?.activeAddress?.address !== receiverAddress) {


### PR DESCRIPTION
## Summary
- Modified `useSell` and `useSwap` hooks to include `includeTx=true` query parameter in `receiveFor` calls
- This enables the backend to return `depositTx` with EIP-7702 delegation data when user has zero gas balance
- Required for EIP-7702 gasless transaction flow on Sell and Swap routes

## Changes
- `packages/react/src/hooks/sell.hook.ts`: Added `?includeTx=true` to receiveFor URL
- `packages/react/src/hooks/swap.hook.ts`: Added `?includeTx=true` to receiveFor URL

## Related
- Fixes the issue where users with zero gas balance were receiving normal transaction flow instead of EIP-7702 delegation flow
- Works together with API PR #2755 and Services PR #802