### PR TITLE
Fix confirmSwap return type to match API response

### DIFF
--- a/packages/react/src/hooks/swap.hook.ts
+++ b/packages/react/src/hooks/swap.hook.ts
@@ -5,10 +5,11 @@ import { useUser } from './user.hook';
 import { useUserContext } from '../contexts/user.context';
 import { ApiError } from '../definitions/error';
 import { useSessionContext } from '../contexts/session.context';
+import { Transaction } from '../definitions/transaction';
 
 export interface SwapInterface {
   receiveFor: (info: SwapPaymentInfo) => Promise<Swap>;
-  confirmSwap: (id: number, data: ConfirmSwapData) => Promise<void>;
+  confirmSwap: (id: number, data: ConfirmSwapData) => Promise<Transaction>;
 }
 
 export function useSwap(): SwapInterface {
@@ -42,8 +43,8 @@ export function useSwap(): SwapInterface {
   );
 
   const confirmSwap = useCallback(
-    async (id: number, data: ConfirmSwapData): Promise<void> => {
-      return call<void>({ url: SwapUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
+    async (id: number, data: ConfirmSwapData): Promise<Transaction> => {
+      return call<Transaction>({ url: SwapUrl.confirm.replace(':id', id.toString()), method: 'POST', data });
     },
     [call],
   );


### PR DESCRIPTION
## Summary
- Fix `confirmSwap` return type from `Promise<void>` to `Promise<Transaction>` to match actual API response
- Add missing `Transaction` import to swap.hook.ts

## Problem
The `confirmSwap` hook had incorrect return type `Promise<void>`, but the backend API endpoint returns `TransactionDto` with an `id` field. This caused TypeScript compilation errors when accessing `result.id` in the EIP-7702 delegation flow.

## Solution
Updated the type definition and implementation in `swap.hook.ts` to properly reflect the API contract:
- Interface: `confirmSwap: (id: number, data: ConfirmSwapData) => Promise<Transaction>`
- Implementation: `return call<Transaction>({ ... })`

## Test Plan
- [x] Verify TypeScript compilation succeeds
- [x] Check that confirmSwap properly returns transaction data with id field
- [ ] Test Swap flow with EIP-7702 delegation in browser