### PR TITLE
Add ApiException class for proper Error inheritance

### DIFF
--- a/packages/react/src/definitions/error.ts
+++ b/packages/react/src/definitions/error.ts
@@ -6,3 +6,14 @@ export interface ApiError {
   statusCode: number;
   message: string;
 }
+
+export class ApiException extends Error implements ApiError {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiException';
+    Object.setPrototypeOf(this, ApiException.prototype);
+  }
+}

--- a/packages/react/src/hooks/api.hook.ts
+++ b/packages/react/src/hooks/api.hook.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useAuthContext } from '../contexts/auth.context';
-import { ApiError } from '../definitions/error';
+import { ApiError, ApiException } from '../definitions/error';
 
 export interface ApiInterface {
   defaultUrl: string;
@@ -46,10 +46,7 @@ export function useApi(): ApiInterface {
     )
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
-        throw {
-          statusCode: 0,
-          message: `Network error: ${message}`,
-        } as ApiError;
+        throw new ApiException(0, `Network error: ${message}`);
       })
       .then((response) => {
         if (response.status === config.specialHandling?.statusCode) {
@@ -71,9 +68,14 @@ export function useApi(): ApiInterface {
           }
         }
 
-        return response.json().then((body) => {
-          throw body;
-        });
+        return response.json()
+          .catch(() => null)
+          .then((body: Partial<ApiError> | null) => {
+            throw new ApiException(
+              body?.statusCode ?? response.status,
+              body?.message ?? response.statusText ?? 'Unknown error',
+            );
+          });
       });
   }, [url, defaultVersion]);
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -40,7 +40,7 @@ export { Bank } from './definitions/bank';
 export { Blockchain } from './definitions/blockchain';
 export { Buy, BuyPaymentInfo, PdfDocument } from './definitions/buy';
 export { Country } from './definitions/country';
-export { ApiError } from './definitions/error';
+export { ApiError, ApiException } from './definitions/error';
 export { Fiat } from './definitions/fiat';
 export { CustomFile } from './definitions/file';
 export {


### PR DESCRIPTION
## Summary
Replace plain `ApiError` objects with `ApiException` class that extends `Error`, so error handlers can properly display the message.

## Problem
The previous implementation threw plain objects `{statusCode, message}`. When these objects were caught by error handlers (webpack-dev-server overlay, browser console), they were displayed as `[object Object]` instead of the actual error message.

## Solution

### 1. ApiException class
```typescript
export class ApiException extends Error implements ApiError {
  constructor(
    public readonly statusCode: number,
    message: string,
  ) {
    super(message);
    this.name = 'ApiException';
    Object.setPrototypeOf(this, ApiException.prototype);
  }
}
```

**Features:**
- Extends `Error` → proper `.message`, `.stack`, `toString()`
- Implements `ApiError` → backward compatible
- `Object.setPrototypeOf` → ES5 prototype chain fix

### 2. Network error handling
```typescript
.catch((error: unknown) => {
  const message = error instanceof Error ? error.message : String(error);
  throw new ApiException(0, `Network error: ${message}`);
})
```

### 3. API error handling with fallbacks
```typescript
return response.json()
  .catch(() => null)
  .then((body: Partial<ApiError> | null) => {
    throw new ApiException(
      body?.statusCode ?? response.status,
      body?.message ?? response.statusText ?? 'Unknown error',
    );
  });
```

**Edge cases handled:**

| Server Response | statusCode | message |
|----------------|------------|---------|
| `{"statusCode": 400, "message": "Error"}` | 400 | "Error" |
| `{"error": "Bad"}` | response.status | response.statusText |
| `["error"]` | response.status | response.statusText |
| `"string"` | response.status | response.statusText |
| `null` | response.status | response.statusText |
| HTML/invalid JSON | response.status | response.statusText |

## Test Plan
- [ ] Network error → `Network error: Failed to fetch`
- [ ] API error → actual error message
- [ ] Non-JSON response → HTTP status text
- [ ] `error.statusCode` works
- [ ] `error.message` works
- [ ] `error instanceof Error` → `true`
- [ ] `error instanceof ApiException` → `true`