### PR TITLE
Make includeTx parameter optional in receiveFor hooks

### DIFF
--- a/packages/react/src/hooks/sell.hook.ts
+++ b/packages/react/src/hooks/sell.hook.ts
@@ -6,7 +6,7 @@ import { Transaction } from '../definitions/transaction';
 import { useApi } from './api.hook';
 
 export interface SellInterface {
-  receiveFor: (info: SellPaymentInfo) => Promise<Sell>;
+  receiveFor: (info: SellPaymentInfo, includeTx?: boolean) => Promise<Sell>;
   confirmSell: (id: number, data: ConfirmSellData) => Promise<Transaction>;
   currencies?: Fiat[];
 }
@@ -16,8 +16,9 @@ export function useSell(): SellInterface {
   const { currencies } = useFiatContext();
 
   const receiveFor = useCallback(
-    async (info: SellPaymentInfo): Promise<Sell> => {
-      return call<Sell>({ url: `${SellUrl.receive}?includeTx=true`, method: 'PUT', data: info });
+    async (info: SellPaymentInfo, includeTx = false): Promise<Sell> => {
+      const url = includeTx ? `${SellUrl.receive}?includeTx=true` : SellUrl.receive;
+      return call<Sell>({ url, method: 'PUT', data: info });
     },
     [call],
   );

--- a/packages/react/src/hooks/swap.hook.ts
+++ b/packages/react/src/hooks/swap.hook.ts
@@ -8,7 +8,7 @@ import { useSessionContext } from '../contexts/session.context';
 import { Transaction } from '../definitions/transaction';
 
 export interface SwapInterface {
-  receiveFor: (info: SwapPaymentInfo) => Promise<Swap>;
+  receiveFor: (info: SwapPaymentInfo, includeTx?: boolean) => Promise<Swap>;
   confirmSwap: (id: number, data: ConfirmSwapData) => Promise<Transaction>;
 }
 
@@ -19,8 +19,9 @@ export function useSwap(): SwapInterface {
   const { tokenStore } = useSessionContext();
 
   const receiveFor = useCallback(
-    async (info: SwapPaymentInfo): Promise<Swap> => {
-      const request = { url: `${SwapUrl.receive}?includeTx=true`, method: 'PUT', data: info } as CallConfig;
+    async (info: SwapPaymentInfo, includeTx = false): Promise<Swap> => {
+      const url = includeTx ? `${SwapUrl.receive}?includeTx=true` : SwapUrl.receive;
+      const request = { url, method: 'PUT', data: info } as CallConfig;
       const { receiverAddress } = info;
 
       if (receiverAddress && user?.activeAddress?.address !== receiverAddress) {


### PR DESCRIPTION
## Summary
- Add `includeTx` parameter to `sell.hook.ts` `receiveFor` (default: `false`)
- Add `includeTx` parameter to `swap.hook.ts` `receiveFor` (default: `false`)
- Only request `depositTx` when explicitly needed (e.g., when user clicks send button)

## Problem
The API was attempting to create a deposit transaction even when the user is just viewing a price quote. This caused "insufficient funds for intrinsic transaction cost" errors when the wallet has insufficient gas for transaction estimation.

## Solution
Make `includeTx` an optional parameter that defaults to `false`. Consumers should pass `includeTx=true` only when they actually need the prepared transaction (i.e., when the user is ready to send).

## Usage
```typescript
// Just getting a quote (no depositTx needed)
const quote = await receiveFor(paymentInfo);

// Ready to send transaction (need depositTx)
const sellWithTx = await receiveFor(paymentInfo, true);
```

## Test plan
- [ ] Verify sell quote works without errors
- [ ] Verify swap quote works without errors
- [ ] Verify `includeTx=true` still returns `depositTx` when needed