### PR TITLE
Add userNonce to Eip7702DelegationData

### DIFF
--- a/packages/react/src/definitions/sell.ts
+++ b/packages/react/src/definitions/sell.ts
@@ -14,6 +14,7 @@ export interface Eip7702DelegationData {
   relayerAddress: string;
   delegationManagerAddress: string;
   delegatorAddress: string;
+  userNonce: number;
   domain: {
     name: string;
     version: string;


### PR DESCRIPTION
## Summary
- Add `userNonce: number` field to `Eip7702DelegationData` interface
- Required for correct EIP-7702 authorization signing (nonce was previously hardcoded to 0)

This change is needed in conjunction with the API fix (PR #2813) which now returns the user's account nonce in the EIP-7702 delegation data.