### PR TITLE
Add usePaymaster and paymasterUrl fields to UnsignedTx interface

### DIFF
--- a/packages/react/src/definitions/sell.ts
+++ b/packages/react/src/definitions/sell.ts
@@ -44,6 +44,8 @@ export interface UnsignedTx {
   gasPrice: string;
   gasLimit: string;
   eip7702?: Eip7702DelegationData;
+  usePaymaster?: boolean;
+  paymasterUrl?: string;
 }
 
 export interface Sell {


### PR DESCRIPTION
## Summary
- Add `usePaymaster?: boolean` field to `UnsignedTx` interface
- Add `paymasterUrl?: string` field to `UnsignedTx` interface

These fields are needed for ERC-5792 `wallet_sendCalls` Paymaster integration, allowing gasless transactions via ERC-7677 Paymaster service.

## Context
Part of the EIP-7702 migration from manual signing (broken due to `eth_sign` being disabled in MetaMask) to `wallet_sendCalls` with Paymaster sponsorship.

## Test plan
- [x] Package builds successfully
- [ ] Frontend services build after updating to this version