### PR TITLE
Replace EIP-7702 with EIP-5792 for gasless transactions

### DIFF
--- a/packages/react/src/definitions/sell.ts
+++ b/packages/react/src/definitions/sell.ts
@@ -10,28 +10,17 @@ export const SellUrl = {
   confirm: 'sell/paymentInfos/:id/confirm'
 };
 
-export interface Eip7702DelegationData {
-  relayerAddress: string;
-  delegationManagerAddress: string;
-  delegatorAddress: string;
-  userNonce: number;
-  domain: {
-    name: string;
-    version: string;
-    chainId: number;
-    verifyingContract: string;
-  };
-  types: {
-    Delegation: Array<{ name: string; type: string }>;
-    Caveat: Array<{ name: string; type: string }>;
-  };
-  message: {
-    delegate: string;
-    delegator: string;
-    authority: string;
-    caveats: any[];
-    salt: string;
-  };
+// EIP-5792 wallet_sendCalls data for gasless transactions
+export interface Eip5792Call {
+  to: string;
+  data: string;
+  value: string;
+}
+
+export interface Eip5792Data {
+  paymasterUrl: string;
+  chainId: number;
+  calls: Eip5792Call[];
 }
 
 export interface UnsignedTx {
@@ -43,9 +32,7 @@ export interface UnsignedTx {
   nonce: number;
   gasPrice: string;
   gasLimit: string;
-  eip7702?: Eip7702DelegationData;
-  usePaymaster?: boolean;
-  paymasterUrl?: string;
+  eip5792?: Eip5792Data;
 }
 
 export interface Sell {
@@ -91,27 +78,7 @@ export interface SellPaymentInfo {
   exactPrice?: boolean;
 }
 
-export interface Eip7702Authorization {
-  chainId: number | string;
-  address: string;
-  nonce: number | string;
-  r: string;
-  s: string;
-  yParity: number;
-}
-
-export interface Eip7702SignedData {
-  delegation: {
-    delegate: string;
-    delegator: string;
-    authority: string;
-    salt: string;
-    signature: string;
-  };
-  authorization: Eip7702Authorization;
-}
-
 export interface ConfirmSellData {
   signedTxHex?: string;
-  eip7702?: Eip7702SignedData;
+  txHash?: string; // Transaction hash from wallet_sendCalls
 }

--- a/packages/react/src/definitions/swap.ts
+++ b/packages/react/src/definitions/swap.ts
@@ -1,7 +1,7 @@
 import { Asset } from './asset';
 import { Fees } from './fees';
 import { PriceStep } from './price-step';
-import { Eip7702DelegationData, UnsignedTx, Eip7702SignedData } from './sell';
+import { UnsignedTx } from './sell';
 import { TransactionError } from './transaction';
 
 export const SwapUrl = {
@@ -47,5 +47,5 @@ export interface SwapPaymentInfo {
 
 export interface ConfirmSwapData {
   signedTxHex?: string;
-  eip7702?: Eip7702SignedData;
+  txHash?: string; // Transaction hash from wallet_sendCalls
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -136,7 +136,7 @@ export {
   GoodsCategory,
   isStepDone,
 } from './definitions/kyc';
-export { Sell, SellPaymentInfo, Beneficiary, UnsignedTx, Eip7702DelegationData, Eip7702SignedData, Eip7702Authorization, ConfirmSellData } from './definitions/sell';
+export { Sell, SellPaymentInfo, Beneficiary, UnsignedTx, Eip5792Data, Eip5792Call, ConfirmSellData } from './definitions/sell';
 export { Swap, SwapPaymentInfo, ConfirmSwapData } from './definitions/swap';
 export { Session } from './definitions/session';
 export {


### PR DESCRIPTION
## Summary
- Remove EIP-7702 types (Eip7702DelegationData, Eip7702SignedData, Eip7702Authorization)
- Add EIP-5792 types (Eip5792Data, Eip5792Call) for wallet_sendCalls with paymasterService
- Update UnsignedTx to use eip5792 instead of eip7702
- Update ConfirmSellData/ConfirmSwapData to use txHash instead of eip7702

## Why
MetaMask has eth_sign disabled by default since 2023, which blocks the current EIP-7702 gasless transaction flow. EIP-5792 wallet_sendCalls with paymasterService capability is the modern solution that works without eth_sign.

## Breaking Changes
- `Eip7702DelegationData`, `Eip7702SignedData`, `Eip7702Authorization` interfaces removed
- `UnsignedTx.eip7702` replaced with `UnsignedTx.eip5792`
- `ConfirmSellData.eip7702` and `ConfirmSwapData.eip7702` replaced with `txHash`

## Test plan
- [ ] Build succeeds
- [ ] Types are exported correctly