### PR TITLE
feat: add setTransactionBankRefund for creditor data submission

### DIFF
--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -6,6 +6,7 @@ export const TransactionUrl = {
   unassigned: 'transaction/unassigned',
   target: 'transaction/target',
   refund: (id: number) => `transaction/${id}/refund`,
+  bankRefund: (id: number) => `transaction/${id}/bank-refund`,
   setTarget: (id: number) => `transaction/${id}/target`,
   invoice: (id: number) => `transaction/${id}/invoice`,
   receipt: (id: number) => `transaction/${id}/receipt`,
@@ -226,6 +227,16 @@ export interface TransactionHistoryQuery {
 
 export interface TransactionRefundTarget {
   refundTarget: string;
+}
+
+export interface BankRefundData {
+  refundTarget: string;
+  name: string;
+  address: string;
+  houseNumber?: string;
+  zip: string;
+  city: string;
+  country: string;
 }
 
 export type TransactionFilterKey = keyof TransactionFilter;

--- a/packages/react/src/hooks/transaction.hook.ts
+++ b/packages/react/src/hooks/transaction.hook.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { ResponseType, useApi } from './api.hook';
 import {
+  BankRefundData,
   DetailTransaction,
   ExportType,
   Transaction,
@@ -29,6 +30,7 @@ export interface TransactionInterface {
   setTransactionTarget: (transactionId: number, buyId: number) => Promise<void>;
   getTransactionRefund: (id: number) => Promise<TransactionRefundData>;
   setTransactionRefundTarget: (id: number, target: TransactionRefundTarget) => Promise<void>;
+  setTransactionBankRefund: (id: number, data: BankRefundData) => Promise<void>;
 }
 
 export function useTransaction(): TransactionInterface {
@@ -164,6 +166,13 @@ export function useTransaction(): TransactionInterface {
     [call],
   );
 
+  const setTransactionBankRefund = useCallback(
+    async (id: number, data: BankRefundData): Promise<void> => {
+      return call<void>({ url: `${TransactionUrl.bankRefund(id)}`, method: 'PUT', data });
+    },
+    [call],
+  );
+
   return useMemo(
     () => ({
       getTransactions,
@@ -180,6 +189,7 @@ export function useTransaction(): TransactionInterface {
       setTransactionTarget,
       getTransactionRefund,
       setTransactionRefundTarget,
+      setTransactionBankRefund,
     }),
     [
       getTransactions,
@@ -196,6 +206,7 @@ export function useTransaction(): TransactionInterface {
       setTransactionTarget,
       getTransactionRefund,
       setTransactionRefundTarget,
+      setTransactionBankRefund,
     ],
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -170,8 +170,10 @@ export {
   TransactionTarget,
   TransactionFilter,
   RefundFeeData,
+  RefundBankDetails,
   TransactionRefundData,
   TransactionRefundTarget,
+  BankRefundData,
   TransactionFilterKey,
 } from './definitions/transaction';
 export { Fees } from './definitions/fees';


### PR DESCRIPTION
## Summary
- Add `bankRefund` URL to `TransactionUrl` for `PUT /transaction/{id}/bank-refund`
- Add `BankRefundData` interface with creditor fields (name, address, houseNumber, zip, city, country)
- Add `setTransactionBankRefund()` hook function to submit bank refund with creditor data
- Export `BankRefundData` and `RefundBankDetails` from package index

## Context
Enables frontend to submit creditor data when customers request bank refunds for buy transactions. The backend already has the `PUT /transaction/{id}/bank-refund` endpoint that accepts `BankRefundDto`.

## Files Changed
- `packages/react/src/definitions/transaction.ts` - URL + interface
- `packages/react/src/hooks/transaction.hook.ts` - hook function
- `packages/react/src/index.ts` - exports