### PR TITLE
fix: correct bank-refund endpoint URL

### DIFF
--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -6,7 +6,7 @@ export const TransactionUrl = {
   unassigned: 'transaction/unassigned',
   target: 'transaction/target',
   refund: (id: number) => `transaction/${id}/refund`,
-  bankRefund: (id: number) => `transaction/${id}/bank-refund`,
+  bankRefund: (id: number) => `transaction/${id}/refund/bank`,
   setTarget: (id: number) => `transaction/${id}/target`,
   invoice: (id: number) => `transaction/${id}/invoice`,
   receipt: (id: number) => `transaction/${id}/receipt`,


### PR DESCRIPTION
## Summary
Fix the bank refund endpoint URL to match the backend API.

## Change
- From: `/transaction/:id/bank-refund`
- To: `/transaction/:id/refund/bank`

## Problem
The frontend was calling the wrong endpoint, causing `Cannot PUT /v1/transaction/11/bank-refund` error when submitting bank refunds.