### PR TITLE
Support uid parameter for getTransactionInvoice

### DIFF
--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -8,7 +8,7 @@ export const TransactionUrl = {
   refund: (id: number) => `transaction/${id}/refund`,
   bankRefund: (id: number) => `transaction/${id}/refund/bank`,
   setTarget: (id: number) => `transaction/${id}/target`,
-  invoice: (id: number) => `transaction/${id}/invoice`,
+  invoice: (id: number | string) => `transaction/${id}/invoice`,
   receipt: (id: number) => `transaction/${id}/receipt`,
 };
 

--- a/packages/react/src/hooks/transaction.hook.ts
+++ b/packages/react/src/hooks/transaction.hook.ts
@@ -21,7 +21,7 @@ export interface TransactionInterface {
   getTransactionByCkoId: (ckoId: string) => Promise<Transaction>;
   getTransactionByRequestId: (requestId: number) => Promise<Transaction>;
   getTransactionCsv: (from?: Date, to?: Date) => Promise<string>;
-  getTransactionInvoice: (id: number) => Promise<PdfDocument>;
+  getTransactionInvoice: (id: number | string) => Promise<PdfDocument>;
   getTransactionReceipt: (id: number) => Promise<PdfDocument>;
   getTransactionHistory: (type: ExportType, queryParams: TransactionHistoryQuery) => Promise<string>;
   getUnassignedTransactions: () => Promise<UnassignedTransaction[]>;
@@ -103,7 +103,7 @@ export function useTransaction(): TransactionInterface {
   );
 
   const getTransactionInvoice = useCallback(
-    async (id: number): Promise<PdfDocument> => {
+    async (id: number | string): Promise<PdfDocument> => {
       return call<PdfDocument>({
         url: `${TransactionUrl.invoice(id)}`,
         method: 'PUT',


### PR DESCRIPTION
## Summary
- Change `TransactionUrl.invoice` to accept `number | string`
- Update `getTransactionInvoice` signature to accept `number | string`

## Why
Pending transactions (e.g., "Warten auf Zahlung") don't have a numeric `id`, only a `uid`. This change allows fetching invoices using the uid.

## Related PRs
- API: DFXswiss/api#3029
- Services: (pending)

## Test plan
- [x] Build passes