### PR TITLE
fix: publish workflow blocked by branch protection

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
@@ -40,7 +42,8 @@ jobs:
           git config user.email "info@dfx.swiss"
           npm config set provenance true
 
-          npx lerna version --conventional-commits --conventional-prerelease --preid beta --yes
+          npx lerna version --conventional-commits --conventional-prerelease --preid beta --yes --no-push
+          git push origin --tags
           npx lerna publish from-git --yes --dist-tag beta
 
       - name: "Version and publish (stable)"
@@ -50,5 +53,6 @@ jobs:
           git config user.email "info@dfx.swiss"
           npm config set provenance true
 
-          npx lerna version --conventional-commits --conventional-graduate --yes
+          npx lerna version --conventional-commits --conventional-graduate --yes --no-push
+          git push origin --tags
           npx lerna publish from-git --yes


### PR DESCRIPTION
## Summary
- Add `--no-push` to `lerna version` to prevent direct push to protected branch
- Push only tags separately with `git push origin --tags`
- Add `fetch-depth: 0` for proper conventional commit history analysis

## Context
The publish workflow fails with `GH013: Repository rule violations found for refs/heads/develop` because `lerna version` tries to push the version commit directly to the protected develop branch. With `--no-push`, lerna creates the version commit and tags locally, then we push only the tags (which aren't subject to branch protection). `lerna publish from-git` then publishes based on those tags.

## Test plan
- [ ] Merge this PR and verify the publish workflow succeeds on develop
- [ ] Verify npm packages are published with correct beta versions
- [ ] Verify git tags are created on the remote