### PR TITLE
feat: add Firo blockchain support

### DIFF
--- a/packages/react/src/definitions/blockchain.ts
+++ b/packages/react/src/definitions/blockchain.ts
@@ -2,6 +2,7 @@ export enum Blockchain {
   BITCOIN = 'Bitcoin',
   LIGHTNING = 'Lightning',
   SPARK = 'Spark',
+  FIRO = 'Firo',
   MONERO = 'Monero',
   ZANO = 'Zano',
   ETHEREUM = 'Ethereum',

--- a/packages/react/src/definitions/route.ts
+++ b/packages/react/src/definitions/route.ts
@@ -70,6 +70,7 @@ export const PaymentLinkBlockchain = {
   LIGHTNING: Blockchain.LIGHTNING,
   SPARK: Blockchain.SPARK,
   BITCOIN: Blockchain.BITCOIN,
+  FIRO: Blockchain.FIRO,
   MONERO: Blockchain.MONERO,
   OPTIMISM: Blockchain.OPTIMISM,
   POLYGON: Blockchain.POLYGON,


### PR DESCRIPTION
## Summary
- Add `FIRO = 'Firo'` to the `Blockchain` enum
- Add `FIRO: Blockchain.FIRO` to the `PaymentLinkBlockchain` mapping

## Test plan
- [ ] Verify Firo appears in blockchain enum consumers
- [ ] Verify payment link routing works for Firo