### PR TITLE
feat: use dedicated PUT /v2/user/phone endpoint

### DIFF
--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -44,6 +44,7 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
   const {
     getUser,
     updateUser: updateUserApi,
+    updatePhone: updatePhoneApi,
     updateMail: updateMailApi,
     verifyMail: verifyMailApi,
     addSpecialCode,
@@ -103,8 +104,13 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
   }, [user, verifyMailApi]);
 
   const updatePhone = useCallback(async (phone: string): Promise<void> => {
-    return updateUser({ phone });
-  }, [updateUser]);
+    if (!user) return;
+
+    setIsUserUpdating(true);
+    return updatePhoneApi(phone)
+      .then(setUser)
+      .finally(() => setIsUserUpdating(false));
+  }, [user, updatePhoneApi]);
 
   const updateLanguage = useCallback(async (language: Language): Promise<void> => {
     return updateUser({ language });

--- a/packages/react/src/definitions/user.ts
+++ b/packages/react/src/definitions/user.ts
@@ -18,6 +18,7 @@ export const UserUrl = {
   changeAddress: 'user/change',
   specialCodes: 'user/specialCodes',
   profile: 'user/profile',
+  updatePhone: 'user/phone',
 };
 
 export enum UserStatus {
@@ -109,7 +110,6 @@ export interface User {
 }
 
 export interface UpdateUser {
-  phone?: string;
   language?: Language;
   currency?: Fiat;
   preferredPhoneTimes?: PhoneCallPreferredTime[];

--- a/packages/react/src/hooks/user.hook.ts
+++ b/packages/react/src/hooks/user.hook.ts
@@ -9,6 +9,7 @@ export interface UserInterface {
   getRef: () => Promise<Referral | undefined>;
   getProfile: () => Promise<UserProfile | undefined>;
   updateUser: (user?: Partial<User>, userLinkAction?: () => void) => Promise<User | undefined>;
+  updatePhone: (phone: string) => Promise<User | undefined>;
   updateMail: (mail: string) => Promise<void>;
   verifyMail: (token: string) => Promise<User>;
   changeUserAddress: (address: string) => Promise<SignIn>;
@@ -47,6 +48,15 @@ export function useUser(): UserInterface {
         action: userLinkAction,
         statusCode: 202,
       },
+    });
+  }
+
+  async function updatePhone(phone: string): Promise<User | undefined> {
+    return call<User>({
+      url: UserUrl.updatePhone,
+      version: 'v2',
+      method: 'PUT',
+      data: { phone },
     });
   }
 
@@ -125,6 +135,7 @@ export function useUser(): UserInterface {
       getRef,
       getProfile,
       updateUser,
+      updatePhone,
       updateMail,
       verifyMail,
       changeUserAddress,


### PR DESCRIPTION
## Summary
- Add `UserUrl.updatePhone` pointing to `user/phone`
- Add dedicated `updatePhone()` hook function calling `PUT /v2/user/phone`
- Update `UserContextProvider` to use the new dedicated endpoint instead of `updateUser({ phone })`
- Remove `phone` from `UpdateUser` interface (no longer accepted by `PUT /v2/user`)

Companion to DFXswiss/api#3368

## Test plan
- [ ] Phone edit button on account screen calls `PUT /v2/user/phone`
- [ ] Phone edit button on settings screen calls `PUT /v2/user/phone`
- [ ] Language/currency updates via `PUT /v2/user` still work
- [ ] Build compiles without errors