### PR TITLE
feat: add Ark blockchain support

### DIFF
--- a/packages/react/src/definitions/blockchain.ts
+++ b/packages/react/src/definitions/blockchain.ts
@@ -2,6 +2,7 @@ export enum Blockchain {
   BITCOIN = 'Bitcoin',
   LIGHTNING = 'Lightning',
   SPARK = 'Spark',
+  ARK = 'Ark',
   FIRO = 'Firo',
   MONERO = 'Monero',
   ZANO = 'Zano',

--- a/packages/react/src/definitions/route.ts
+++ b/packages/react/src/definitions/route.ts
@@ -69,6 +69,7 @@ export const PaymentLinkBlockchain = {
   ETHEREUM: Blockchain.ETHEREUM,
   LIGHTNING: Blockchain.LIGHTNING,
   SPARK: Blockchain.SPARK,
+  ARK: Blockchain.ARK,
   BITCOIN: Blockchain.BITCOIN,
   FIRO: Blockchain.FIRO,
   INTERNET_COMPUTER: Blockchain.INTERNET_COMPUTER,


### PR DESCRIPTION
## Summary
- Add `ARK = 'Ark'` to `Blockchain` enum
- Add `ARK: Blockchain.ARK` to `PaymentLinkBlockchain` in route definitions

Required for Ark (Arkade) Bitcoin L2 integration in API and Services.