### PR TITLE
Add bankFixed and bankPercent to Fees interface

### DIFF
--- a/packages/react/src/definitions/fees.ts
+++ b/packages/react/src/definitions/fees.ts
@@ -4,6 +4,8 @@ export interface Fees {
   min: number;
   dfx: number;
   bank: number;
+  bankFixed?: number;
+  bankPercent?: number;
   network: number;
   total: number;
   networkStart?: number;


### PR DESCRIPTION
## Summary
- Add optional `bankFixed` and `bankPercent` fields to `Fees` interface
- Enables separate display of bank fee components in the frontend
- Backwards compatible: both fields are optional

## Related PRs
- API: https://github.com/DFXswiss/api/pull/3448
- Services: (follows after this package is published)

## Test plan
- [ ] Build succeeds
- [ ] Existing consumers compile without changes