### PR TITLE
Add language parameter to authentication API

### DIFF
--- a/packages/react/src/contexts/session.context.tsx
+++ b/packages/react/src/contexts/session.context.tsx
@@ -22,6 +22,7 @@ export interface SessionInterface {
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ) => Promise<string>;
   login: (address?: string, signature?: string, discount?: string) => Promise<string | undefined>;
   signUp: (
@@ -112,11 +113,20 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ): Promise<string> {
     setIsProcessing(true);
-    return createApiSessionNew(address, signature, key, discount, wallet, ref, walletType, recommendationCode).finally(
-      () => setIsProcessing(false),
-    );
+    return createApiSessionNew(
+      address,
+      signature,
+      key,
+      discount,
+      wallet,
+      ref,
+      walletType,
+      recommendationCode,
+      language,
+    ).finally(() => setIsProcessing(false));
   }
 
   async function login(

--- a/packages/react/src/hooks/api-session.hook.ts
+++ b/packages/react/src/hooks/api-session.hook.ts
@@ -19,6 +19,7 @@ export interface ApiSessionInterface {
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ) => Promise<string>;
   createSessionNew: (
     address: string,
@@ -29,6 +30,7 @@ export interface ApiSessionInterface {
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ) => Promise<string>;
   updateSession: (token: string) => void;
   deleteSession: () => Promise<void>;
@@ -38,44 +40,52 @@ export function useApiSession(): ApiSessionInterface {
   const { isInitialized, isLoggedIn, session, setAuthToken } = useAuthContext();
   const { getSignMessage, authenticate, signIn, signUp } = useAuth();
 
-  const createSession = useCallback(async (
-    isSignUp: boolean,
-    address: string,
-    signature: string,
-    key?: string,
-    discount?: string,
-    wallet?: string,
-    ref?: string,
-    walletType?: AuthWalletType,
-    recommendationCode?: string,
-  ): Promise<string> => {
-    return (
-      isSignUp
-        ? signUp(address, signature, key, discount, wallet, ref, walletType, recommendationCode)
-        : signIn(address, signature, key, discount, walletType)
-    ).then(({ accessToken }) => {
-      setAuthToken(accessToken);
-      return accessToken;
-    });
-  }, [signUp, signIn, setAuthToken]);
-
-  const createSessionNew = useCallback(async (
-    address: string,
-    signature: string,
-    key?: string,
-    discount?: string,
-    wallet?: string,
-    ref?: string,
-    walletType?: AuthWalletType,
-    recommendationCode?: string,
-  ) => {
-    return authenticate(address, signature, key, discount, wallet, ref, walletType, recommendationCode).then(
-      ({ accessToken }) => {
+  const createSession = useCallback(
+    async (
+      isSignUp: boolean,
+      address: string,
+      signature: string,
+      key?: string,
+      discount?: string,
+      wallet?: string,
+      ref?: string,
+      walletType?: AuthWalletType,
+      recommendationCode?: string,
+      language?: string,
+    ): Promise<string> => {
+      return (
+        isSignUp
+          ? signUp(address, signature, key, discount, wallet, ref, walletType, recommendationCode, language)
+          : signIn(address, signature, key, discount, walletType)
+      ).then(({ accessToken }) => {
         setAuthToken(accessToken);
         return accessToken;
-      },
-    );
-  }, [authenticate, setAuthToken]);
+      });
+    },
+    [signUp, signIn, setAuthToken],
+  );
+
+  const createSessionNew = useCallback(
+    async (
+      address: string,
+      signature: string,
+      key?: string,
+      discount?: string,
+      wallet?: string,
+      ref?: string,
+      walletType?: AuthWalletType,
+      recommendationCode?: string,
+      language?: string,
+    ) => {
+      return authenticate(address, signature, key, discount, wallet, ref, walletType, recommendationCode, language).then(
+        ({ accessToken }) => {
+          setAuthToken(accessToken);
+          return accessToken;
+        },
+      );
+    },
+    [authenticate, setAuthToken],
+  );
 
   const updateSession = useCallback((token: string) => {
     setAuthToken(token);

--- a/packages/react/src/hooks/auth.hook.ts
+++ b/packages/react/src/hooks/auth.hook.ts
@@ -14,6 +14,7 @@ export interface AuthInterface {
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ) => Promise<SignIn>;
   signIn: (
     address: string,
@@ -31,6 +32,7 @@ export interface AuthInterface {
     ref?: string,
     walletType?: AuthWalletType,
     recommendationCode?: string,
+    language?: string,
   ) => Promise<SignIn>;
   signInWithMail: (mail: string, redirectUri?: string, recommendationCode?: string) => Promise<void>;
   createLnurlAuth: () => Promise<LnurlAuth>;
@@ -47,6 +49,7 @@ interface SignUpParams {
   usedRef?: string;
   walletType?: AuthWalletType;
   recommendationCode?: string;
+  language?: string;
 }
 
 export function useAuth(): AuthInterface {
@@ -62,8 +65,18 @@ export function useAuth(): AuthInterface {
       usedRef?: string,
       walletType?: AuthWalletType,
       recommendationCode?: string,
+      language?: string,
     ): SignUpParams => {
-      const params: SignUpParams = { address, signature, key, usedRef, specialCode, walletType, recommendationCode };
+      const params: SignUpParams = {
+        address,
+        signature,
+        key,
+        usedRef,
+        specialCode,
+        walletType,
+        recommendationCode,
+        language,
+      };
 
       if (wallet) {
         const walletId = parseInt(wallet);
@@ -98,8 +111,19 @@ export function useAuth(): AuthInterface {
       usedRef?: string,
       walletType?: AuthWalletType,
       recommendationCode?: string,
+      language?: string,
     ): Promise<SignIn> => {
-      const data = getParams(address, signature, key, specialCode, wallet, usedRef, walletType, recommendationCode);
+      const data = getParams(
+        address,
+        signature,
+        key,
+        specialCode,
+        wallet,
+        usedRef,
+        walletType,
+        recommendationCode,
+        language,
+      );
       const config: CallConfig = { url: AuthUrl.auth, method: 'POST', data };
 
       return call<SignIn>(config).catch((e: ApiError) => {
@@ -135,8 +159,19 @@ export function useAuth(): AuthInterface {
       usedRef?: string,
       walletType?: AuthWalletType,
       recommendationCode?: string,
+      language?: string,
     ): Promise<SignIn> => {
-      const data = getParams(address, signature, key, specialCode, wallet, usedRef, walletType, recommendationCode);
+      const data = getParams(
+        address,
+        signature,
+        key,
+        specialCode,
+        wallet,
+        usedRef,
+        walletType,
+        recommendationCode,
+        language,
+      );
       return call({ url: AuthUrl.signUp, method: 'POST', data });
     },
     [call, getParams],


### PR DESCRIPTION
## Summary
- Add optional `language` parameter to `authenticate`, `signUp`, and `createSession` methods
- Allows frontend to pass browser language preference during user registration
- Supports the API change to use browser language instead of IP-based language detection

## Test plan
- [ ] Build passes
- [ ] Test with services frontend passing `navigator.language`

🤖 Generated with [Claude Code](https://claude.ai/code)