### PR TITLE
feat: add support dashboard enums and Marketing role

### DIFF
--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -140,7 +140,9 @@ export {
   SupportIssueType,
   SupportIssueReason,
   SupportIssueState,
+  SupportIssueInternalState,
   SupportMessageStatus,
+  Department,
 } from './support';
 export type {
   Reaction,

--- a/packages/core/src/definitions/jwt.ts
+++ b/packages/core/src/definitions/jwt.ts
@@ -11,6 +11,7 @@ export enum UserRole {
   KYC_CLIENT_COMPANY = 'KycClientCompany',
   CUSTODY = 'Custody',
   REALUNIT = 'RealUnit',
+  MARKETING = 'Marketing',
 }
 
 export interface Jwt {

--- a/packages/core/src/definitions/support.ts
+++ b/packages/core/src/definitions/support.ts
@@ -47,6 +47,21 @@ export enum SupportIssueState {
   CANCELED = 'Canceled',
 }
 
+export enum SupportIssueInternalState {
+  CREATED = 'Created',
+  PENDING = 'Pending',
+  COMPLETED = 'Completed',
+  CANCELED = 'Canceled',
+  ON_HOLD = 'OnHold',
+}
+
+export enum Department {
+  SUPPORT = 'Support',
+  COMPLIANCE = 'Compliance',
+  MARKETING = 'Marketing',
+  COOPERATION = 'Cooperation',
+}
+
 export enum SupportMessageStatus {
   SENT = 'Sent',
   RECEIVED = 'Received',

--- a/packages/react/src/definitions/jwt.ts
+++ b/packages/react/src/definitions/jwt.ts
@@ -11,6 +11,7 @@ export enum UserRole {
   KYC_CLIENT_COMPANY = 'KycClientCompany',
   CUSTODY = 'Custody',
   REALUNIT = 'RealUnit',
+  MARKETING = 'Marketing',
 }
 
 export interface Jwt {

--- a/packages/react/src/definitions/support.ts
+++ b/packages/react/src/definitions/support.ts
@@ -47,6 +47,21 @@ export enum SupportIssueState {
   CANCELED = 'Canceled',
 }
 
+export enum SupportIssueInternalState {
+  CREATED = 'Created',
+  PENDING = 'Pending',
+  COMPLETED = 'Completed',
+  CANCELED = 'Canceled',
+  ON_HOLD = 'OnHold',
+}
+
+export enum Department {
+  SUPPORT = 'Support',
+  COMPLIANCE = 'Compliance',
+  MARKETING = 'Marketing',
+  COOPERATION = 'Cooperation',
+}
+
 export enum SupportMessageStatus {
   SENT = 'Sent',
   RECEIVED = 'Received',

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -205,7 +205,9 @@ export {
   BlobContent,
   DataFile,
   SupportIssueState,
+  SupportIssueInternalState,
   SupportMessageStatus,
+  Department,
   Reaction,
 } from './definitions/support';
 


### PR DESCRIPTION
## Summary
- Add `SupportIssueInternalState` enum (Created, Pending, Completed, Canceled, OnHold)
- Add `Department` enum (Support, Compliance, Marketing, Cooperation)
- Add `MARKETING` value to `UserRole` enum
- Changes applied to both `core` and `react` packages

## Test plan
- [ ] Verify enums are correctly exported from both packages
- [ ] Build packages successfully