### PR TITLE
feat: add STOPPED transaction state

### DIFF
--- a/packages/react/src/definitions/transaction.ts
+++ b/packages/react/src/definitions/transaction.ts
@@ -72,6 +72,7 @@ export enum TransactionState {
   RETURNED = 'Returned',
   UNASSIGNED = 'Unassigned',
   WAITING_FOR_PAYMENT = 'WaitingForPayment',
+  STOPPED = 'Stopped',
 }
 
 export enum TransactionFailureReason {


### PR DESCRIPTION
## Summary
- Add `STOPPED` enum value to `TransactionState` in `packages/react/src/definitions/transaction.ts`.
- Companion change for the new compliance "stop transaction" feature in api and services.

## Test plan
- [ ] Consumed by api: `BuyCryptoStatus.STOPPED` is mapped to `TransactionState.STOPPED` by the transaction DTO mapper.
- [ ] Consumed by services: stop-transaction button shows the new state in the UI.