### PR TITLE
Fix npm publish pipeline for @dfx.swiss/core

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ env:
   NODE_VERSION: "18.x"
 
 permissions:
-  id-token: write
   contents: write
 
 jobs:
@@ -35,20 +34,22 @@ jobs:
 
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
-          npm config set provenance true
 
           npx lerna version --conventional-commits --conventional-prerelease --preid beta --yes
           npx lerna publish from-git --yes --dist-tag beta
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
-          npm config set provenance true
 
           npx lerna version --conventional-commits --conventional-graduate --yes
           npx lerna publish from-git --yes

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,7 @@ env:
   NODE_VERSION: "18.x"
 
 permissions:
+  id-token: write
   contents: write
 
 jobs:
@@ -34,8 +35,6 @@ jobs:
 
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
@@ -45,8 +44,6 @@ jobs:
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"


### PR DESCRIPTION
## Summary

- Remove `npm config set provenance true` — root cause of E404 when publishing `@dfx.swiss/core`
- Core was initially published manually without provenance attestation, causing all subsequent CI publishes to fail with E404
- **All package publishes have been broken since March 20** (over a month)
- Use explicit `NODE_AUTH_TOKEN` secret instead of OIDC-based auth

## Context

The publish pipeline failed because npm provenance requires consistent attestation. Core was first published manually (by `taprootfreak`), so npm rejected provenance-enabled CI publishes. React and react-components continued to publish despite the pipeline being marked as "failure".

## Test plan

- [ ] Merge and verify publish workflow succeeds
- [ ] Verify all three packages are published to npm