### PR TITLE
Fix npm publish: use token auth instead of OIDC

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ env:
   NODE_VERSION: "18.x"
 
 permissions:
-  id-token: write
   contents: write
 
 jobs:
@@ -35,6 +34,8 @@ jobs:
 
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
@@ -44,6 +45,8 @@ jobs:
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ env:
   NODE_VERSION: "18.x"
 
 permissions:
-  id-token: write
   contents: write
 
 jobs:
@@ -35,20 +34,22 @@ jobs:
 
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
-          npm config set provenance true
 
           npx lerna version --conventional-commits --conventional-prerelease --preid beta --yes
           npx lerna publish from-git --yes --dist-tag beta
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
-          npm config set provenance true
 
           npx lerna version --conventional-commits --conventional-graduate --yes
           npx lerna publish from-git --yes

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,7 @@ env:
   NODE_VERSION: "18.x"
 
 permissions:
+  id-token: write
   contents: write
 
 jobs:
@@ -34,8 +35,6 @@ jobs:
 
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
@@ -45,8 +44,6 @@ jobs:
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"


### PR DESCRIPTION
## Summary

- Replace OIDC-based npm auth with explicit `NODE_AUTH_TOKEN` secret
- Remove `id-token: write` permission (no longer needed)
- Root cause: OIDC auth returned E404 for `@dfx.swiss/core` because the package was initially published with token auth, not OIDC

## Context

All package publishes have been failing since March 20 (~1 month). The E404 persisted even after removing npm provenance (#150), confirming the issue is OIDC auth itself, not provenance signing.

## Changes

- `permissions.id-token: write` → removed
- `npm config set provenance true` → already removed in #150
- `NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}` → added to publish steps