### PR TITLE
Remove unnecessary skipLibCheck from core tsconfig

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -5,7 +5,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "skipLibCheck": true
+    "lib": ["dom", "dom.iterable", "esnext"]
   }
 }


### PR DESCRIPTION
## Summary

- Remove `skipLibCheck: true` from `packages/core/tsconfig.build.json`

## Why

`skipLibCheck` was added in #152 but is not needed — all three packages build cleanly without it. The flag suppresses type-checking of `.d.ts` files, which can mask real type errors in dependencies. Removing it restores full type safety during builds.

## Verified

- `tsc -b packages/core/tsconfig.build.json` — passes
- `tsc -b packages/react/tsconfig.build.json` — passes
- `tsc -b packages/react-components/tsconfig.build.json` — passes