### PR TITLE
Add automatic sync from main to develop after stable publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
@@ -53,3 +55,11 @@ jobs:
 
           npx lerna version --conventional-commits --conventional-graduate --yes
           npx lerna publish from-git --yes
+
+      - name: "Sync main back to develop"
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git fetch origin develop:develop
+          git checkout develop
+          git merge main -X theirs -m "chore: sync main into develop after release [skip ci]"
+          git push origin develop


### PR DESCRIPTION
## Summary
- Adds an automatic back-merge step in the publish workflow that syncs main into develop after every stable release
- Uses `git merge -X theirs` to resolve version/changelog conflicts in favor of main's stable versions
- Uses `[skip ci]` to prevent triggering unnecessary beta publishes from the sync commit
- Adds `fetch-depth: 0` to checkout for full git history (required for the merge)

## Problem
After `lerna version --conventional-graduate` runs on main, it creates a "Publish" commit with stable versions and changelog entries. This commit never gets back-merged into develop. The next release PR (develop → main) always has merge conflicts in `package.json`, `CHANGELOG.md`, and `package-lock.json` because both branches independently modified these files.

This was previously fixed manually (commits `2a2e7fb`, `e8ebee6`) but recurred with every release cycle.

## How it works
1. Stable publish runs on main as before
2. New step fetches develop, merges main into it with `-X theirs` (main's versions win on conflicts)
3. Pushes develop with `[skip ci]` to avoid triggering a new beta publish cycle
4. Next feature merge to develop triggers normal beta versioning from the synced state

## Test plan
- [ ] Merge this PR into develop
- [ ] Merge the existing release PR (#157) into main
- [ ] Verify the publish workflow creates the sync commit on develop automatically
- [ ] Verify no unnecessary beta publish is triggered by the sync
- [ ] Next release PR from develop to main should be conflict-free