### PR TITLE
Reorder CI steps for fail-fast: lint before build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: Build, test and lint
+    name: Lint, build and test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,14 +27,6 @@ jobs:
         run: |
           npm install
 
-      - name: Build code
-        run: |
-          npx lerna run build
-
-      - name: Run tests
-        run: |
-          npx lerna run test
-
       - name: Run linter
         run: |
           npx lerna run lint
@@ -42,3 +34,11 @@ jobs:
       - name: Check formatting
         run: |
           npx lerna run format:check
+
+      - name: Build code
+        run: |
+          npx lerna run build
+
+      - name: Run tests
+        run: |
+          npx lerna run test


### PR DESCRIPTION
## Summary
- Move lint and format:check steps before build and test in PR CI workflow
- Fast checks (~seconds) run first, slow steps (~minutes) run after
- Provides quicker feedback on style issues without waiting for a full build cycle

Closes #158

## Test plan
- [ ] Verify PR CI workflow runs steps in new order: lint → format:check → build → test
- [ ] Confirm lint/format failures still block the pipeline