### PR TITLE
Add compliance definitions for pending reviews and call queues

### DIFF
--- a/packages/core/src/definitions/compliance.ts
+++ b/packages/core/src/definitions/compliance.ts
@@ -1,0 +1,64 @@
+import { AmlReason, CheckStatus } from './aml';
+import { AccountType } from './kyc';
+import { PhoneCallStatus } from './user';
+
+export enum PendingReviewType {
+  KYC_STEP = 'KycStep',
+  BANK_DATA = 'BankData',
+}
+
+export enum PendingReviewStatus {
+  MANUAL_REVIEW = 'ManualReview',
+  INTERNAL_REVIEW = 'InternalReview',
+}
+
+export interface PendingReviewSummaryEntry {
+  type: PendingReviewType;
+  name: string;
+  manualReview: number;
+  internalReview: number;
+}
+
+export interface PendingReviewItem {
+  id: number;
+  userDataId: number;
+  userName?: string;
+  accountType?: AccountType;
+  kycLevel?: number;
+  date: string;
+}
+
+export enum CallQueue {
+  MANUAL_CHECK_PHONE = 'ManualCheckPhone',
+  MANUAL_CHECK_IP_PHONE = 'ManualCheckIpPhone',
+  MANUAL_CHECK_IP_COUNTRY_PHONE = 'ManualCheckIpCountryPhone',
+  MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE = 'ManualCheckExternalAccountPhone',
+  UNAVAILABLE_SUSPICIOUS = 'UnavailableSuspicious',
+}
+
+export type CallQueueSourceType = 'BuyCrypto' | 'BuyFiat';
+
+export interface CallQueueSummaryEntry {
+  queue: CallQueue;
+  count: number;
+}
+
+export interface CallQueueItem {
+  queue: CallQueue;
+  userDataId: number;
+  userName?: string;
+  phone?: string;
+  language?: string;
+  country?: string;
+  kycLevel?: number;
+  txId?: number;
+  sourceType?: CallQueueSourceType;
+  amlCheck?: CheckStatus;
+  amlReason?: AmlReason;
+  inputAmount?: number;
+  inputAsset?: string;
+  ip?: string;
+  ipCountry?: string;
+  phoneCallStatus?: PhoneCallStatus;
+  date: string;
+}

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -1,4 +1,12 @@
 export { CheckStatus, AmlReason } from './aml';
+export { PendingReviewType, PendingReviewStatus, CallQueue } from './compliance';
+export type {
+  PendingReviewSummaryEntry,
+  PendingReviewItem,
+  CallQueueSourceType,
+  CallQueueSummaryEntry,
+  CallQueueItem,
+} from './compliance';
 export { AssetUrl, AssetType, AssetCategory } from './asset';
 export type { Asset } from './asset';
 export { AuthUrl, AuthWalletType } from './auth';

--- a/packages/core/src/definitions/user.ts
+++ b/packages/core/src/definitions/user.ts
@@ -41,6 +41,10 @@ export enum PhoneCallStatus {
   UNAVAILABLE = 'Unavailable',
   COMPLETED = 'Completed',
   FAILED = 'Failed',
+  REPEAT = 'Repeat',
+  USER_REJECTED = 'UserRejected',
+  SUSPICIOUS = 'Suspicious',
+  MANUAL_CHECK = 'ManualCheck',
 }
 
 export interface VolumeInformation {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,10 @@ export {
   // AML
   CheckStatus,
   AmlReason,
+  // Compliance
+  PendingReviewType,
+  PendingReviewStatus,
+  CallQueue,
   // Asset
   AssetUrl,
   AssetType,
@@ -116,6 +120,12 @@ export {
 export type {
   // Asset
   Asset,
+  // Compliance
+  PendingReviewSummaryEntry,
+  PendingReviewItem,
+  CallQueueSourceType,
+  CallQueueSummaryEntry,
+  CallQueueItem,
   // Auth
   SignMessage,
   SignIn,

--- a/packages/react/src/definitions/compliance.ts
+++ b/packages/react/src/definitions/compliance.ts
@@ -1,0 +1,9 @@
+export { PendingReviewType, PendingReviewStatus, CallQueue } from '@dfx.swiss/core';
+
+export type {
+  PendingReviewSummaryEntry,
+  PendingReviewItem,
+  CallQueueSourceType,
+  CallQueueSummaryEntry,
+  CallQueueItem,
+} from '@dfx.swiss/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -35,6 +35,16 @@ export { useSupportChat } from './hooks/support.hook';
 
 // Definitions
 export { CheckStatus, AmlReason } from './definitions/aml';
+export {
+  PendingReviewType,
+  PendingReviewStatus,
+  CallQueue,
+  PendingReviewSummaryEntry,
+  PendingReviewItem,
+  CallQueueSourceType,
+  CallQueueSummaryEntry,
+  CallQueueItem,
+} from './definitions/compliance';
 export { Asset, AssetType, AssetCategory, AssetUrl } from './definitions/asset';
 export { BankAccount, BankAccountUrl } from './definitions/bank-account';
 export { Bank, BankUrl } from './definitions/bank';


### PR DESCRIPTION
## Summary
- Adds shared types and enums for the new compliance pending-reviews and call-queue features, consumed by both api and services
- Extends `PhoneCallStatus` with `REPEAT`, `USER_REJECTED`, `SUSPICIOUS`, `MANUAL_CHECK`
- `react` re-exports the new compliance symbols from `core`

## Test plan
- [ ] `npx tsc --noEmit` clean in core and react
- [ ] Consumers (api, services) build green against the linked `dist/`
- [ ] No breaking changes to existing exports — only additions