### PR TITLE
feat: expose machine-readable error code from API responses

### DIFF
--- a/packages/core/src/client/DfxHttpClient.ts
+++ b/packages/core/src/client/DfxHttpClient.ts
@@ -72,7 +72,7 @@ export class DfxHttpClient {
 
   private async rawRequest<T>(config: RequestConfig): Promise<T> {
     const responseType = config.responseType ?? ResponseType.JSON;
-    const token = config.token === false ? undefined : (config.token ?? this.authToken);
+    const token = config.token === false ? undefined : config.token ?? this.authToken;
 
     let response: Response;
     try {
@@ -109,6 +109,7 @@ export class DfxHttpClient {
     throw new ApiException(
       body?.statusCode ?? response.status,
       body?.message ?? response.statusText ?? 'Unknown error',
+      body?.code,
     );
   }
 

--- a/packages/core/src/client/DfxHttpClient.ts
+++ b/packages/core/src/client/DfxHttpClient.ts
@@ -72,7 +72,7 @@ export class DfxHttpClient {
 
   private async rawRequest<T>(config: RequestConfig): Promise<T> {
     const responseType = config.responseType ?? ResponseType.JSON;
-    const token = config.token === false ? undefined : config.token ?? this.authToken;
+    const token = config.token === false ? undefined : (config.token ?? this.authToken);
 
     let response: Response;
     try {

--- a/packages/core/src/definitions/error.ts
+++ b/packages/core/src/definitions/error.ts
@@ -5,13 +5,15 @@ export interface ApiError {
    */
   statusCode: number;
   message: string;
+  /**
+   * Machine-readable error code from the API response body (e.g. 'TFA_REQUIRED',
+   * 'KYC_LEVEL_REQUIRED'). Absent for generic errors.
+   */
+  code?: string;
 }
 
 export class ApiException extends Error implements ApiError {
-  constructor(
-    public readonly statusCode: number,
-    message: string,
-  ) {
+  constructor(public readonly statusCode: number, message: string, public readonly code?: string) {
     super(message);
     this.name = 'ApiException';
     Object.setPrototypeOf(this, ApiException.prototype);

--- a/packages/core/src/definitions/error.ts
+++ b/packages/core/src/definitions/error.ts
@@ -13,7 +13,11 @@ export interface ApiError {
 }
 
 export class ApiException extends Error implements ApiError {
-  constructor(public readonly statusCode: number, message: string, public readonly code?: string) {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly code?: string,
+  ) {
     super(message);
     this.name = 'ApiException';
     Object.setPrototypeOf(this, ApiException.prototype);


### PR DESCRIPTION
## Summary
Adds an optional `code` field to `ApiError` and `ApiException`, and surfaces it from `DfxHttpClient.rawRequest` when the API response body carries one. Consumers can now match on a stable, machine-readable code (e.g. `TFA_REQUIRED`, `KYC_LEVEL_REQUIRED`, `REGISTRATION_REQUIRED`) instead of using `statusCode + message.includes(...)` heuristics.

## Why this is needed

Today, `ApiError` only carries `statusCode` and `message`. Any consumer that needs to react specifically to *2FA required* (vs. *account blocked* vs. *country not allowed* — all `403`s) is forced into a brittle heuristic:

```ts
// Today, in services/src/screens/kyc.screen.tsx:260
} else if (e.statusCode === 403 && e.message?.includes('2FA')) {
  navigate('/2fa', { setRedirect: true });
}
```

This breaks the moment the backend changes its message text and silently misroutes other 403s into the 2FA flow.

The DFX backend (DFXswiss/api) already emits a `code` field in many error responses (currently `KYC_LEVEL_REQUIRED`, `REGISTRATION_REQUIRED`, and shortly `TFA_REQUIRED` via DFXswiss/api#3629). `DfxHttpClient` was discarding it. This PR stops discarding it.

## Change
1. `packages/core/src/definitions/error.ts`
   - `ApiError` interface gets an optional `code?: string`
   - `ApiException` constructor gets a third optional argument `code?: string` exposed as a `public readonly` field
2. `packages/core/src/client/DfxHttpClient.ts:108-113`
   - The `rawRequest` error path now passes `body?.code` through to the `ApiException` constructor

## Compatibility

- **Public surface:** `code` is optional everywhere. Existing constructions of `new ApiException(status, message)` still type-check and behave identically.
- **Bundle size / runtime:** trivial — a single extra constructor argument and one assignment.
- **Re-exports:** `@dfx.swiss/react` already does `export type { ApiError } from '@dfx.swiss/core'`, so consumers of `react` automatically pick up the new field once they upgrade.

## Follow-ups

- DFXswiss/services — switch `kyc.screen.tsx:260` from the `message.includes('2FA')` heuristic to `e.code === 'TFA_REQUIRED'` (separate PR, depends on this being published).
- DFXswiss/api#3629 — the backend PR that introduces `TFA_REQUIRED` as a stable code.

## Test plan
- [ ] Bump `@dfx.swiss/core` (and re-publish `@dfx.swiss/react`), pull into a consumer, hit any endpoint that returns `{statusCode, code, message}` (e.g. KYC level required), confirm `error.code` is now populated.
- [ ] Confirm responses **without** a `code` field still produce a working `ApiException` with `code === undefined`.