### PR TITLE
fix: resolve 3 ESLint warnings in @dfx.swiss/core

### DIFF
--- a/packages/core/src/client/DfxApiClient.ts
+++ b/packages/core/src/client/DfxApiClient.ts
@@ -1,4 +1,4 @@
-import { DfxHttpClient, DfxHttpClientConfig } from './DfxHttpClient';
+import { DfxHttpClient } from './DfxHttpClient';
 import { AuthApi } from './AuthApi';
 import { AssetApi } from './AssetApi';
 import { BankApi } from './BankApi';

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -4,7 +4,7 @@ import PhoneNumber from 'libphonenumber-js';
 import { Country } from './definitions/country';
 
 const regex = {
-  Mail: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  Mail: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
 };
 
 export type RequiredRule = {


### PR DESCRIPTION
## Summary
- Remove unused import `DfxHttpClientConfig` in `DfxApiClient.ts` (`@typescript-eslint/no-unused-vars`)
- Remove 2 unnecessary escape characters in mail regex in `validations.ts` (`no-useless-escape`)

Resolves the `@dfx.swiss/core` portion of #166 (3 of 93 warnings).

## Test plan
- [x] `eslint` reports 0 warnings for `@dfx.swiss/core`
- [x] `tsc` build passes