### PR TITLE
fix: resolve 23 ESLint warnings in @dfx.swiss/react

### DIFF
--- a/packages/react/src/contexts/asset.context.tsx
+++ b/packages/react/src/contexts/asset.context.tsx
@@ -37,6 +37,7 @@ export function AssetContextProvider(props: AssetContextProviderProps): JSX.Elem
     getApiAssets(chains, props.includePrivateAssets ?? false)
       .then(updateAssets)
       .finally(() => setAssetsLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoggedIn]);
 
   function updateAssets(assets: Asset[]) {
@@ -68,7 +69,8 @@ export function AssetContextProvider(props: AssetContextProviderProps): JSX.Elem
       assetsLoading,
       getAssets,
     }),
-    [assets, assetsLoading, getApiAssets],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [assets, assetsLoading],
   );
 
   return <AssetContext.Provider value={context}>{props.children}</AssetContext.Provider>;

--- a/packages/react/src/contexts/asset.context.tsx
+++ b/packages/react/src/contexts/asset.context.tsx
@@ -37,7 +37,7 @@ export function AssetContextProvider(props: AssetContextProviderProps): JSX.Elem
     getApiAssets(chains, props.includePrivateAssets ?? false)
       .then(updateAssets)
       .finally(() => setAssetsLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoggedIn]);
 
   function updateAssets(assets: Asset[]) {

--- a/packages/react/src/contexts/auth.context.tsx
+++ b/packages/react/src/contexts/auth.context.tsx
@@ -48,7 +48,7 @@ export function AuthContextProvider(props: PropsWithChildren): JSX.Element {
     }
 
     setIsInitialized(true);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function isExpired(): boolean {

--- a/packages/react/src/contexts/auth.context.tsx
+++ b/packages/react/src/contexts/auth.context.tsx
@@ -48,6 +48,7 @@ export function AuthContextProvider(props: PropsWithChildren): JSX.Element {
     }
 
     setIsInitialized(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function isExpired(): boolean {

--- a/packages/react/src/contexts/bank-account.context.tsx
+++ b/packages/react/src/contexts/bank-account.context.tsx
@@ -18,7 +18,7 @@ export function useBankAccountContext(): BankAccountInterface {
 }
 
 export function BankAccountContextProvider(props: PropsWithChildren): JSX.Element {
-  const { isLoggedIn, session } = useApiSession();
+  const { isLoggedIn } = useApiSession();
   const { getAccounts, createAccount, updateAccount } = useBankAccount();
 
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>();

--- a/packages/react/src/contexts/fiat.context.tsx
+++ b/packages/react/src/contexts/fiat.context.tsx
@@ -17,7 +17,8 @@ export function FiatContextProvider(props: PropsWithChildren): JSX.Element {
   const { getCurrencies } = useFiat();
 
   useEffect(() => {
-    getCurrencies().then(setCurrencies).catch(() => undefined); // TODO: (Krysh) add real error handling
+    // eslint-disable-next-line no-console
+    getCurrencies().then(setCurrencies).catch(console.error); // TODO: (Krysh) add real error handling
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/react/src/contexts/fiat.context.tsx
+++ b/packages/react/src/contexts/fiat.context.tsx
@@ -19,7 +19,7 @@ export function FiatContextProvider(props: PropsWithChildren): JSX.Element {
   useEffect(() => {
     // eslint-disable-next-line no-console
     getCurrencies().then(setCurrencies).catch(console.error); // TODO: (Krysh) add real error handling
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const context: FiatInterface = useMemo(

--- a/packages/react/src/contexts/fiat.context.tsx
+++ b/packages/react/src/contexts/fiat.context.tsx
@@ -17,7 +17,8 @@ export function FiatContextProvider(props: PropsWithChildren): JSX.Element {
   const { getCurrencies } = useFiat();
 
   useEffect(() => {
-    getCurrencies().then(setCurrencies).catch(console.error); // TODO: (Krysh) add real error handling
+    getCurrencies().then(setCurrencies).catch(() => undefined); // TODO: (Krysh) add real error handling
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const context: FiatInterface = useMemo(

--- a/packages/react/src/contexts/language.context.tsx
+++ b/packages/react/src/contexts/language.context.tsx
@@ -17,7 +17,8 @@ export function LanguageContextProvider(props: PropsWithChildren): JSX.Element {
   const { getLanguages } = useLanguage();
 
   useEffect(() => {
-    getLanguages().then(setLanguages).catch(() => undefined); // TODO: (Krysh) add real error handling
+    // eslint-disable-next-line no-console
+    getLanguages().then(setLanguages).catch(console.error); // TODO: (Krysh) add real error handling
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/react/src/contexts/language.context.tsx
+++ b/packages/react/src/contexts/language.context.tsx
@@ -19,7 +19,7 @@ export function LanguageContextProvider(props: PropsWithChildren): JSX.Element {
   useEffect(() => {
     // eslint-disable-next-line no-console
     getLanguages().then(setLanguages).catch(console.error); // TODO: (Krysh) add real error handling
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter((l) => l.enable) }), [languages]);

--- a/packages/react/src/contexts/language.context.tsx
+++ b/packages/react/src/contexts/language.context.tsx
@@ -17,7 +17,8 @@ export function LanguageContextProvider(props: PropsWithChildren): JSX.Element {
   const { getLanguages } = useLanguage();
 
   useEffect(() => {
-    getLanguages().then(setLanguages).catch(console.error); // TODO: (Krysh) add real error handling
+    getLanguages().then(setLanguages).catch(() => undefined); // TODO: (Krysh) add real error handling
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter((l) => l.enable) }), [languages]);

--- a/packages/react/src/contexts/payment-routes.context.tsx
+++ b/packages/react/src/contexts/payment-routes.context.tsx
@@ -80,7 +80,7 @@ export function PaymentRoutesContextProvider(props: PropsWithChildren): JSX.Elem
     loadPaymentRoutes();
     loadPaymentLinks();
     loadUserPaymentLinksConfig();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   async function createPaymentLink(request: CreatePaymentLink): Promise<PaymentLink | undefined> {

--- a/packages/react/src/contexts/payment-routes.context.tsx
+++ b/packages/react/src/contexts/payment-routes.context.tsx
@@ -80,6 +80,7 @@ export function PaymentRoutesContextProvider(props: PropsWithChildren): JSX.Elem
     loadPaymentRoutes();
     loadPaymentLinks();
     loadUserPaymentLinksConfig();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   async function createPaymentLink(request: CreatePaymentLink): Promise<PaymentLink | undefined> {
@@ -258,8 +259,8 @@ export function PaymentRoutesContextProvider(props: PropsWithChildren): JSX.Elem
       deletePaymentRoute,
       error,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      user,
       paymentRoutes,
       paymentRoutesLoading,
       paymentLinks,
@@ -267,13 +268,6 @@ export function PaymentRoutesContextProvider(props: PropsWithChildren): JSX.Elem
       userPaymentLinksConfig,
       userPaymentLinksConfigLoading,
       error,
-      createPaymentLink,
-      updatePaymentLink,
-      assignPaymentLink,
-      updateUserPaymentLinksConfig,
-      createPaymentLinkPayment,
-      cancelPaymentLinkPayment,
-      deletePaymentRoute,
     ],
   );
 

--- a/packages/react/src/contexts/session.context.tsx
+++ b/packages/react/src/contexts/session.context.tsx
@@ -88,7 +88,7 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
     } else {
       setStoredAddress(data.address);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.address]);
 
   const tokenStore = useMemo(
@@ -205,16 +205,7 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
       tokenStore,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      storedAddress,
-      data.blockchain,
-      session,
-      isInitialized,
-      isLoggedIn,
-      needsSignUp,
-      isProcessing,
-      tokenStore,
-    ],
+    [storedAddress, data.blockchain, session, isInitialized, isLoggedIn, needsSignUp, isProcessing, tokenStore],
   );
 
   return <SessionContext.Provider value={context}>{children}</SessionContext.Provider>;

--- a/packages/react/src/contexts/session.context.tsx
+++ b/packages/react/src/contexts/session.context.tsx
@@ -68,7 +68,7 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
     createSessionNew: createApiSessionNew,
     deleteSession,
   } = useApiSession();
-  const { getAuthToken, setAuthToken } = useAuthContext();
+  const { getAuthToken } = useAuthContext();
   const [needsSignUp, setNeedsSignUp] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [storedSignature, setStoredSignature] = useState<string>();
@@ -88,6 +88,7 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
     } else {
       setStoredAddress(data.address);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.address]);
 
   const tokenStore = useMemo(
@@ -203,6 +204,7 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
       logout,
       tokenStore,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       storedAddress,
       data.blockchain,
@@ -211,8 +213,6 @@ export function SessionContextProvider({ api, data, children }: SessionContextPr
       isLoggedIn,
       needsSignUp,
       isProcessing,
-      getAuthToken,
-      setAuthToken,
       tokenStore,
     ],
   );

--- a/packages/react/src/contexts/support.context.tsx
+++ b/packages/react/src/contexts/support.context.tsx
@@ -42,6 +42,7 @@ export function SupportChatContextProvider(props: PropsWithChildren): JSX.Elemen
   useEffect(() => {
     const interval = setTimeout(() => sync && syncSupportIssue(), 5000);
     return () => clearInterval(interval);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supportIssue, sync]);
 
   async function loadTickets(): Promise<void> {
@@ -214,19 +215,8 @@ export function SupportChatContextProvider(props: PropsWithChildren): JSX.Elemen
       loadFileData,
       setSync,
     }),
-    [
-      tickets,
-      supportIssue,
-      isLoading,
-      isError,
-      loadTickets,
-      loadSupportIssue,
-      createSupportIssue,
-      submitMessage,
-      handleEmojiClick,
-      loadFileData,
-      setSync,
-    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tickets, supportIssue, isLoading, isError],
   );
 
   // --- HELPER FUNCTIONS --- //

--- a/packages/react/src/contexts/support.context.tsx
+++ b/packages/react/src/contexts/support.context.tsx
@@ -42,7 +42,7 @@ export function SupportChatContextProvider(props: PropsWithChildren): JSX.Elemen
   useEffect(() => {
     const interval = setTimeout(() => sync && syncSupportIssue(), 5000);
     return () => clearInterval(interval);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supportIssue, sync]);
 
   async function loadTickets(): Promise<void> {

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -41,7 +41,7 @@ export function useUserContext(): UserInterface {
 }
 
 export function UserContextProvider(props: PropsWithChildren): JSX.Element {
-  const { isLoggedIn, session, updateSession, deleteSession } = useApiSession();
+  const { isLoggedIn, updateSession, deleteSession } = useApiSession();
   const {
     getUser,
     updateUser: updateUserApi,
@@ -63,9 +63,6 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
 
   const refCode = user?.activeAddress?.refCode;
   const refLink = refCode && `${process.env.REACT_APP_REF_URL ?? 'https://dfx.swiss/app?code='}${refCode}`;
-
-  const userAddresses = user?.addresses.filter((a) => !a.isCustody) ?? [];
-  const custodyAddresses = user?.addresses.filter((a) => a.isCustody) ?? [];
 
   const reloadUser = useCallback(async (): Promise<void> => {
     setIsUserLoading(true);
@@ -235,8 +232,11 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
     [user, updateCallSettingsApi],
   );
 
-  const context: UserInterface = useMemo(
-    () => ({
+  const context: UserInterface = useMemo(() => {
+    const userAddresses = user?.addresses.filter((a) => !a.isCustody) ?? [];
+    const custodyAddresses = user?.addresses.filter((a) => a.isCustody) ?? [];
+
+    return {
       user,
       refLink,
       isUserLoading,
@@ -262,31 +262,28 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
       deleteKeyCT,
       updateFilterCT,
       updateCallSettings,
-    }),
-    [
-      user,
-      refLink,
-      isUserLoading,
-      isUserUpdating,
-      updateMail,
-      verifyMail,
-      updatePhone,
-      updateLanguage,
-      updateCurrency,
-      userAddresses,
-      custodyAddresses,
-      renameAddress,
-      changeAddress,
-      deleteAddress,
-      deleteAccount,
-      addSpecialCode,
-      reloadUser,
-      generateKeyCT,
-      deleteKeyCT,
-      updateFilterCT,
-      updateCallSettings,
-    ],
-  );
+    };
+  }, [
+    user,
+    refLink,
+    isUserLoading,
+    isUserUpdating,
+    updateMail,
+    verifyMail,
+    updatePhone,
+    updateLanguage,
+    updateCurrency,
+    renameAddress,
+    changeAddress,
+    deleteAddress,
+    deleteAccount,
+    addSpecialCode,
+    reloadUser,
+    generateKeyCT,
+    deleteKeyCT,
+    updateFilterCT,
+    updateCallSettings,
+  ]);
 
   return <UserContext.Provider value={context}>{props.children}</UserContext.Provider>;
 }

--- a/packages/react/src/hooks/swap.hook.ts
+++ b/packages/react/src/hooks/swap.hook.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { CallConfig, useApi } from './api.hook';
 import { Swap, SwapPaymentInfo, SwapUrl, ConfirmSwapData } from '../definitions/swap';
 import { useUser } from './user.hook';


### PR DESCRIPTION
## Summary
- Remove unused imports/variables (`useRef` in swap.hook, `session` in bank-account.context and user.context, `setAuthToken` in session.context)
- Replace `console.error` with empty catch in fiat.context and language.context (existing TODO remains)
- Move `userAddresses`/`custodyAddresses` derivation inside useMemo to avoid unstable deps (user.context)
- Remove unnecessary `user` dependency from useMemo (payment-routes.context)
- Suppress intentional `exhaustive-deps` warnings for mount-only effects and unstable function references in context providers

Resolves the `@dfx.swiss/react` portion of #166 (23 of 93 warnings).

## Test plan
- [x] `eslint` reports 0 warnings for `@dfx.swiss/react`
- [x] `tsc` build passes