### PR TITLE
fix: resolve 67 ESLint warnings in @dfx.swiss/react-components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
       "rules": {
         "no-console": "off"
       }
+    },
+    {
+      "files": ["**/*.stories.{ts,tsx}"],
+      "rules": {
+        "no-console": "off"
+      }
     }
   ],
   "ignorePatterns": ["dist", "node_modules", "*.js"]

--- a/packages/react-components/src/stories/StyledCheckboxRow.stories.tsx
+++ b/packages/react-components/src/stories/StyledCheckboxRow.stories.tsx
@@ -35,7 +35,7 @@ export const Checked: ComponentStory<typeof StyledCheckboxRow> = (args) => {
   return (
     <div className={whiteBG}>
       <StyledCheckboxRow {...args} isChecked={isChecked} onChange={setIsChecked}>
-        Don't show this again.
+        Don&apos;t show this again.
       </StyledCheckboxRow>
     </div>
   );

--- a/packages/react-components/src/stories/StyledModal.stories.tsx
+++ b/packages/react-components/src/stories/StyledModal.stories.tsx
@@ -166,7 +166,7 @@ export const SignaturePopupAlert: ComponentStory<typeof StyledModal> = (args) =>
             blockchain address.
           </h2>
           <StyledCheckboxRow isChecked={isChecked} onChange={setIsChecked} centered>
-            Don't show this again.
+            Don&apos;t show this again.
           </StyledCheckboxRow>
 
           <StyledButton

--- a/packages/react-components/src/stories/StyledSearchInput.tsx
+++ b/packages/react-components/src/stories/StyledSearchInput.tsx
@@ -7,41 +7,43 @@ export interface StyledSearchInputProps {
   noClearButton?: boolean;
 }
 
-const StyledSearchInput = forwardRef<HTMLInputElement, StyledSearchInputProps>(
-  ({ placeholder, onChange: emit, noClearButton }: StyledSearchInputProps, ref) => {
-    const [value, setValue] = useState<string>('');
+const StyledSearchInput = forwardRef<HTMLInputElement, StyledSearchInputProps>(function StyledSearchInput(
+  { placeholder, onChange: emit, noClearButton }: StyledSearchInputProps,
+  ref,
+) {
+  const [value, setValue] = useState<string>('');
 
-    function onChange(search: string) {
-      setValue(search);
-      emit(search);
-    }
+  function onChange(search: string) {
+    setValue(search);
+    emit(search);
+  }
 
-    return (
-      <div className="relative w-full">
-        <div className="absolute left-2 top-[9px]">
-          <DfxIcon icon={IconVariant.SEARCH} color={IconColor.DARK_GRAY} size={IconSize.LG} />
-        </div>
-
-        {!noClearButton && (
-          <div className="absolute right-2 top-[9px]">
-            <button type="button" onClick={() => onChange('')}>
-              <DfxIcon icon={IconVariant.CLOSE} color={IconColor.DARK_GRAY} size={IconSize.LG} />
-            </button>
-          </div>
-        )}
-
-        <input
-          ref={ref}
-          className={`text-base font-normal rounded-md pl-8 ${
-            noClearButton ? 'pr-3' : 'pr-8'
-          } py-2 w-full bg-white text-dfxBlue-800 placeholder:text-dfxGray-600 border border-dfxGray-400 outline-2 outline-dfxBlue-400`}
-          placeholder={placeholder}
-          value={value}
-          onChange={(value) => onChange(value.target.value)}
-        />
+  return (
+    <div className="relative w-full">
+      <div className="absolute left-2 top-[9px]">
+        <DfxIcon icon={IconVariant.SEARCH} color={IconColor.DARK_GRAY} size={IconSize.LG} />
       </div>
-    );
-  },
-);
+
+      {!noClearButton && (
+        <div className="absolute right-2 top-[9px]">
+          <button type="button" onClick={() => onChange('')}>
+            <DfxIcon icon={IconVariant.CLOSE} color={IconColor.DARK_GRAY} size={IconSize.LG} />
+          </button>
+        </div>
+      )}
+
+      <input
+        ref={ref}
+        className={`text-base font-normal rounded-md pl-8 ${
+          noClearButton ? 'pr-3' : 'pr-8'
+        } py-2 w-full bg-white text-dfxBlue-800 placeholder:text-dfxGray-600 border border-dfxGray-400 outline-2 outline-dfxBlue-400`}
+        placeholder={placeholder}
+        value={value}
+        onChange={(value) => onChange(value.target.value)}
+      />
+    </div>
+  );
+});
+StyledSearchInput.displayName = 'StyledSearchInput';
 
 export default StyledSearchInput;

--- a/packages/react-components/src/stories/Typography.tsx
+++ b/packages/react-components/src/stories/Typography.tsx
@@ -1,10 +1,10 @@
 export default function Typography() {
   return (
     <div>
-      <h1>Heading 1 / 28px / "text-2xl font-black"</h1>
-      <h2>Heading 2 / 20px / "text-lg font-bold"</h2>
+      <h1>Heading 1 / 28px / &quot;text-2xl font-black&quot;</h1>
+      <h2>Heading 2 / 20px / &quot;text-lg font-bold&quot;</h2>
       <h3>Heading 3 / 20px / regular</h3>
-      <h4 className="uppercase tracking-widest">Sub • Top • Heading "uppercase tracking-widest" </h4>
+      <h4 className="uppercase tracking-widest">Sub • Top • Heading &quot;uppercase tracking-widest&quot; </h4>
       <h5>Heading 5 (idle) </h5>
       <h6>Heading 6 (idle) </h6>
       <br />
@@ -16,24 +16,24 @@ export default function Typography() {
       </p>
       <br />
       <p className="text-sm">
-        <strong>Small Text "text-sm", 14px / 0.875rem</strong> / Aenean lacinia bibendum nulla sed consectetur. Nullam
-        id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum nulla sed consectetur. Fusce dapibus,
-        tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Morbi leo
-        risus, porta ac consectetur ac, vestibulum at eros.
+        <strong>Small Text &quot;text-sm&quot;, 14px / 0.875rem</strong> / Aenean lacinia bibendum nulla sed
+        consectetur. Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum nulla sed
+        consectetur. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo
+        sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
       </p>
       <br />
       <p className="text-xs">
-        <strong>Very Small Text "text-xs", 12px / 0.75rem</strong> , used for Form Labels // Aenean lacinia bibendum
-        nulla sed consectetur. Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum nulla sed
-        consectetur. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo
-        sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+        <strong>Very Small Text &quot;text-xs&quot;, 12px / 0.75rem</strong> , used for Form Labels // Aenean lacinia
+        bibendum nulla sed consectetur. Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum
+        nulla sed consectetur. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum
+        massa justo sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
       </p>
       <br />
       <p className="text-2xs">
-        <strong>Smallest Text, "text-2xs" 10px / 0.625rem</strong> , used for Form Labels // Aenean lacinia bibendum
-        nulla sed consectetur. Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum nulla sed
-        consectetur. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo
-        sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+        <strong>Smallest Text, &quot;text-2xs&quot; 10px / 0.625rem</strong> , used for Form Labels // Aenean lacinia
+        bibendum nulla sed consectetur. Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean lacinia bibendum
+        nulla sed consectetur. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum
+        massa justo sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
       </p>
     </div>
   );

--- a/packages/react-components/src/stories/form/StyledDateAndTimePicker.tsx
+++ b/packages/react-components/src/stories/form/StyledDateAndTimePicker.tsx
@@ -13,7 +13,7 @@ interface StyledDateAndTimePickerContentProps extends StyledDateAndTimePickerPro
 }
 
 const StyledDateAndTimePicker = forwardRef<HTMLDivElement, StyledDateAndTimePickerProps>(
-  (props: StyledDateAndTimePickerProps, ref) => {
+  (props: StyledDateAndTimePickerProps, _ref) => {
     return (
       <Controller
         control={props.control}
@@ -28,10 +28,10 @@ const StyledDateAndTimePicker = forwardRef<HTMLDivElement, StyledDateAndTimePick
 const Content = forwardRef<HTMLInputElement, StyledDateAndTimePickerContentProps>(
   (
     {
-      control,
-      name,
+      control: _control,
+      name: _name,
       label,
-      rules,
+      rules: _rules,
       disabled,
       error,
       hideLabel,
@@ -138,5 +138,7 @@ const Content = forwardRef<HTMLInputElement, StyledDateAndTimePickerContentProps
     );
   },
 );
+StyledDateAndTimePicker.displayName = 'StyledDateAndTimePicker';
+Content.displayName = 'Content';
 
 export default StyledDateAndTimePicker;

--- a/packages/react-components/src/stories/form/StyledDropdown.tsx
+++ b/packages/react-components/src/stories/form/StyledDropdown.tsx
@@ -2,7 +2,7 @@ import { ControlProps } from './Form';
 import { RefObject, useEffect, useRef, useState } from 'react';
 import DfxIcon, { IconColor, IconSize, IconVariant } from '../DfxIcon';
 import { Controller } from 'react-hook-form';
-import DfxAssetIcon, { AssetIconSize, AssetIconVariant } from '../DfxAssetIcon';
+import DfxAssetIcon, { AssetIconVariant } from '../DfxAssetIcon';
 import { Utils } from '../../utils';
 
 export interface StyledDropdownProps<T> extends ControlProps {
@@ -60,6 +60,7 @@ export default function StyledDropdown<T>({
       element.addEventListener('mousedown', closeDropdown);
       return () => element.removeEventListener('mousedown', closeDropdown);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rootRef, isOpen]);
 
   function closeDropdown(e: Event) {

--- a/packages/react-components/src/stories/form/StyledDropdownMultiChoice.tsx
+++ b/packages/react-components/src/stories/form/StyledDropdownMultiChoice.tsx
@@ -39,7 +39,7 @@ export default function StyledDropdownMultiChoice<T>({
   assetIconFunc,
   rootRef,
   forceEnable,
-  hideBalanceWhenClosed,
+  hideBalanceWhenClosed: _hideBalanceWhenClosed,
   error,
   ...props
 }: StyledDropdownMultiChoiceProps<T>) {
@@ -61,6 +61,7 @@ export default function StyledDropdownMultiChoice<T>({
       element.addEventListener('mousedown', closeDropdown);
       return () => element.removeEventListener('mousedown', closeDropdown);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rootRef, isOpen]);
 
   function closeDropdown(e: Event) {

--- a/packages/react-components/src/stories/form/StyledFileUpload.tsx
+++ b/packages/react-components/src/stories/form/StyledFileUpload.tsx
@@ -23,7 +23,7 @@ interface StyledFileUploadContentProps extends StyledFileUploadProps {
   value: any;
 }
 
-const StyledFileUpload = forwardRef<HTMLInputElement, StyledFileUploadProps>((props: StyledFileUploadProps, ref) => {
+const StyledFileUpload = forwardRef<HTMLInputElement, StyledFileUploadProps>((props: StyledFileUploadProps, _ref) => {
   return (
     <Controller
       control={props.control}
@@ -37,11 +37,11 @@ const StyledFileUpload = forwardRef<HTMLInputElement, StyledFileUploadProps>((pr
 const Content = forwardRef<HTMLInputElement, StyledFileUploadContentProps>(
   (
     {
-      control,
-      name,
+      control: _control,
+      name: _name,
       label,
-      rules,
-      disabled = false,
+      rules: _rules,
+      disabled: _disabled = false,
       error,
       placeholder,
       forceError,
@@ -116,5 +116,7 @@ const Content = forwardRef<HTMLInputElement, StyledFileUploadContentProps>(
     );
   },
 );
+StyledFileUpload.displayName = 'StyledFileUpload';
+Content.displayName = 'Content';
 
 export default StyledFileUpload;

--- a/packages/react-components/src/stories/form/StyledInput.tsx
+++ b/packages/react-components/src/stories/form/StyledInput.tsx
@@ -145,5 +145,6 @@ const StyledInput = forwardRef<HTMLInputElement, StyledInputProps>(
     );
   },
 );
+StyledInput.displayName = 'StyledInput';
 
 export default StyledInput;

--- a/packages/react-components/src/stories/form/StyledSearchDropdown.tsx
+++ b/packages/react-components/src/stories/form/StyledSearchDropdown.tsx
@@ -76,6 +76,7 @@ function StyledSearchDropdown<T>({
       element.addEventListener('mousedown', closeDropdown);
       return () => element.removeEventListener('mousedown', closeDropdown);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rootRef, isOpen]);
 
   function closeDropdown(e: Event) {


### PR DESCRIPTION
## Summary
- Disable `no-console` for `*.stories.tsx` files in eslint config (35 warnings — `console.log` is expected in Storybook mock handlers)
- Escape quotes and apostrophes in JSX text content (`react/no-unescaped-entities`, 14 warnings)
- Remove unused imports/params and prefix with `_` (`@typescript-eslint/no-unused-vars`, 11 warnings)
- Add `displayName` to `forwardRef` components (`react/display-name`, 6 warnings)
- Suppress intentional `exhaustive-deps` in dropdown close-on-outside-click handlers (3 warnings)

Resolves the `@dfx.swiss/react-components` portion of #166 (67 of 93 warnings).

With this PR, all 93 ESLint warnings across all 3 packages are resolved. Closes #166.

## Test plan
- [x] `eslint` reports 0 warnings for all 3 packages
- [x] `tsc` build passes for `@dfx.swiss/react-components`
- [x] `prettier --check` passes
- [x] `@dfx.swiss/core` and `@dfx.swiss/react` unaffected by `.eslintrc.json` change