### PR TITLE
chore: promote ESLint warnings to errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,22 +11,22 @@
   "plugins": ["@typescript-eslint"],
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
-    "no-console": "warn",
+    "no-console": "error",
     "no-return-await": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      "error",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-    "@typescript-eslint/no-empty-function": "warn",
-    "no-empty-pattern": "warn",
-    "no-useless-escape": "warn"
+    "@typescript-eslint/no-empty-function": "error",
+    "no-empty-pattern": "error",
+    "no-useless-escape": "error"
   },
   "overrides": [
     {
@@ -39,8 +39,8 @@
         }
       },
       "rules": {
-        "react/display-name": "warn",
-        "react/no-unescaped-entities": "warn",
+        "react/display-name": "error",
+        "react/no-unescaped-entities": "error",
         "react/prop-types": "off"
       }
     },


### PR DESCRIPTION
## Summary
- Promote all previously warned ESLint rules to errors so CI fails on new violations
- Rules changed: `no-console`, `@typescript-eslint/no-unused-vars`, `no-useless-escape`, `@typescript-eslint/no-empty-function`, `no-empty-pattern`, `react/display-name`, `react/no-unescaped-entities`

Follow-up to #166 — now that all 93 warnings are cleaned up, this prevents regressions.

## Test plan
- [x] All 3 packages lint-clean (0 errors, 0 warnings)