### PR TITLE
feat(bip322-multisig): add BIP-322 P2WSH signature verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40923,6 +40923,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@noble/curves": "^2.2.0",
         "bech32": "^2.0.0",
         "bip32": "^4.0.0",
         "bitcoinjs-lib": "^6.1.7"
@@ -41912,6 +41913,33 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "packages/bip322-multisig/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/bip322-multisig/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/bip322-multisig/node_modules/@sinclair/typebox": {
@@ -49427,6 +49455,7 @@
       "version": "file:packages/bip322-multisig",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@noble/curves": "^2.2.0",
         "@types/jest": "^29.5.14",
         "bech32": "^2.0.0",
         "bip32": "^4.0.0",
@@ -50178,6 +50207,19 @@
             "@types/yargs": "^17.0.33",
             "chalk": "^4.1.2"
           }
+        },
+        "@noble/curves": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+          "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+          "requires": {
+            "@noble/hashes": "2.2.0"
+          }
+        },
+        "@noble/hashes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+          "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
         },
         "@sinclair/typebox": {
           "version": "0.27.10",

--- a/packages/bip322-multisig/jest.config.js
+++ b/packages/bip322-multisig/jest.config.js
@@ -4,6 +4,12 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   transform: {
-    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@noble/curves|@noble/hashes)/)',
+  ],
+  moduleNameMapper: {
+    '^@noble/curves/secp256k1$': '@noble/curves/secp256k1.js',
   },
 };

--- a/packages/bip322-multisig/package.json
+++ b/packages/bip322-multisig/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@dfx.swiss/bip322-multisig",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "description": "Build and sign BIP-322 simple signatures for Bitcoin P2WSH multisig wallets via PSBT",
   "license": "MIT",
   "repository": {
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",
+    "@noble/curves": "^2.2.0",
     "bech32": "^2.0.0",
     "bip32": "^4.0.0",
     "bitcoinjs-lib": "^6.1.7"

--- a/packages/bip322-multisig/src/__tests__/verify.test.ts
+++ b/packages/bip322-multisig/src/__tests__/verify.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { Transaction } from 'bitcoinjs-lib';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { isP2wshAddress, verifyBip322P2wshSignature } from '../verify';
@@ -9,7 +10,7 @@ import { buildSortedMultisigScript, p2wshAddress, p2wshScriptPubKey, bip322Messa
 
 /** Generate a random compressed public key (with corresponding private key). */
 function generateKey() {
-  const priv = secp256k1.utils.randomSecretKey();
+  const priv = randomBytes(32);
   const pub = Buffer.from(secp256k1.getPublicKey(priv, true));
   return { priv, pub };
 }

--- a/packages/bip322-multisig/src/__tests__/verify.test.ts
+++ b/packages/bip322-multisig/src/__tests__/verify.test.ts
@@ -1,0 +1,267 @@
+import { Transaction } from 'bitcoinjs-lib';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { isP2wshAddress, verifyBip322P2wshSignature } from '../verify';
+import {
+  buildSortedMultisigScript,
+  p2wshAddress,
+  p2wshScriptPubKey,
+  bip322MessageHash,
+  buildToSpendTx,
+} from '../core';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random compressed public key (with corresponding private key). */
+function generateKey() {
+  const priv = secp256k1.utils.randomSecretKey();
+  const pub = Buffer.from(secp256k1.getPublicKey(priv, true));
+  return { priv, pub };
+}
+
+/** Build a varint-length-prefixed witness stack (Bitcoin serialization). */
+function encodeWitnessStack(items: Buffer[]): Buffer {
+  const parts: Buffer[] = [encodeVarint(items.length)];
+  for (const item of items) {
+    parts.push(encodeVarint(item.length));
+    parts.push(item);
+  }
+  return Buffer.concat(parts);
+}
+
+function encodeVarint(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const b = Buffer.alloc(3);
+    b[0] = 0xfd;
+    b.writeUInt16LE(n, 1);
+    return b;
+  }
+  const b = Buffer.alloc(5);
+  b[0] = 0xfe;
+  b.writeUInt32LE(n, 1);
+  return b;
+}
+
+/** Compute BIP-322 sighash for a given message + witnessScript. */
+function computeSighash(message: string, witnessScript: Buffer): Buffer {
+  const scriptPubKey = p2wshScriptPubKey(witnessScript);
+  const messageHash = bip322MessageHash(message);
+  const toSpend = buildToSpendTx(messageHash, scriptPubKey);
+
+  const toSign = new Transaction();
+  toSign.version = 0;
+  toSign.locktime = 0;
+  toSign.addInput(toSpend.getHash(), 0, 0);
+  toSign.addOutput(Buffer.from([0x6a]), 0);
+
+  return toSign.hashForWitnessV0(0, witnessScript, 0, Transaction.SIGHASH_ALL);
+}
+
+/** Sign a sighash and return DER-encoded signature with SIGHASH_ALL appended. */
+function signDer(sighash: Buffer, privKey: Uint8Array): Buffer {
+  const derSig = secp256k1.sign(sighash, privKey, { format: 'der' });
+  return Buffer.concat([Buffer.from(derSig), Buffer.from([Transaction.SIGHASH_ALL])]);
+}
+
+/** Sign and produce a BIP-322 base64 witness for a 2-of-3 multisig. */
+function signMultisig(
+  message: string,
+  keys: { priv: Uint8Array; pub: Buffer }[],
+  signerIndices: number[],
+): { address: string; signatureBase64: string; witnessScript: Buffer } {
+  const pubkeys = keys.map((k) => k.pub);
+  const witnessScript = buildSortedMultisigScript(pubkeys, signerIndices.length);
+  const address = p2wshAddress(witnessScript);
+
+  const sighash = computeSighash(message, witnessScript);
+
+  // Sorted pubkeys determine the order in the script
+  const sorted = [...pubkeys].sort(Buffer.compare);
+
+  // Build (signerIndex -> position in sorted list) so we sign in sorted order
+  const signerPubs = signerIndices.map((i) => keys[i]);
+  const orderedSigners = signerPubs
+    .map((k) => ({
+      priv: k.priv,
+      sortedIdx: sorted.findIndex((s) => s.equals(k.pub)),
+    }))
+    .sort((a, b) => a.sortedIdx - b.sortedIdx);
+
+  const sigs: Buffer[] = [];
+  for (const signer of orderedSigners) {
+    sigs.push(signDer(sighash, signer.priv));
+  }
+
+  // Witness stack: [OP_0 dummy, sig1, sig2, ..., witnessScript]
+  const stack: Buffer[] = [Buffer.alloc(0), ...sigs, witnessScript];
+  const signatureBase64 = encodeWitnessStack(stack).toString('base64');
+
+  return { address, signatureBase64, witnessScript };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: isP2wshAddress
+// ---------------------------------------------------------------------------
+
+describe('isP2wshAddress', () => {
+  it('accepts a valid mainnet P2WSH address', () => {
+    expect(
+      isP2wshAddress('bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep'),
+    ).toBe(true);
+  });
+
+  it('rejects a P2WPKH address (20-byte program)', () => {
+    expect(isP2wshAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')).toBe(false);
+  });
+
+  it('rejects a legacy address', () => {
+    expect(isP2wshAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBe(false);
+  });
+
+  it('rejects a testnet P2WSH address', () => {
+    expect(
+      isP2wshAddress(
+        'tb1qrp33g0q5b5698ahp5jnf5yzjmgced69zxx0pehrqcgul8ntf0t4qnmva5v',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a malformed string', () => {
+    expect(isP2wshAddress('not-a-bitcoin-address')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isP2wshAddress('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: verifyBip322P2wshSignature — structural negatives
+// ---------------------------------------------------------------------------
+
+describe('verifyBip322P2wshSignature — structural negatives', () => {
+  it('returns false for empty signature', () => {
+    expect(
+      verifyBip322P2wshSignature(
+        'hello',
+        'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep',
+        '',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for garbage base64', () => {
+    expect(
+      verifyBip322P2wshSignature(
+        'hello',
+        'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep',
+        'AAAA',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for non-P2WSH address', () => {
+    expect(
+      verifyBip322P2wshSignature(
+        'hello',
+        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        'AAAA',
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: verifyBip322P2wshSignature — synthetic 2-of-3 roundtrip
+// ---------------------------------------------------------------------------
+
+describe('verifyBip322P2wshSignature — 2-of-3 roundtrip', () => {
+  const key1 = generateKey();
+  const key2 = generateKey();
+  const key3 = generateKey();
+  const keys = [key1, key2, key3];
+
+  it('verifies a short message', () => {
+    const msg = 'short';
+    const { address, signatureBase64 } = signMultisig(msg, keys, [0, 1]);
+    expect(verifyBip322P2wshSignature(msg, address, signatureBase64)).toBe(true);
+  });
+
+  it('verifies a medium-length message', () => {
+    const msg = 'The quick brown fox jumps over the lazy dog — BIP-322 P2WSH test';
+    const { address, signatureBase64 } = signMultisig(msg, keys, [1, 2]);
+    expect(verifyBip322P2wshSignature(msg, address, signatureBase64)).toBe(true);
+  });
+
+  it('verifies a long message', () => {
+    const msg = 'A'.repeat(500);
+    const { address, signatureBase64 } = signMultisig(msg, keys, [0, 2]);
+    expect(verifyBip322P2wshSignature(msg, address, signatureBase64)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: verifyBip322P2wshSignature — rejection
+// ---------------------------------------------------------------------------
+
+describe('verifyBip322P2wshSignature — rejection', () => {
+  const key1 = generateKey();
+  const key2 = generateKey();
+  const key3 = generateKey();
+  const keys = [key1, key2, key3];
+  const message = 'rejection test message';
+
+  it('rejects under-threshold (1-of-3 when 2 required)', () => {
+    const pubkeys = keys.map((k) => k.pub);
+    const witnessScript = buildSortedMultisigScript(pubkeys, 2);
+    const address = p2wshAddress(witnessScript);
+    const sighash = computeSighash(message, witnessScript);
+
+    // Produce only 1 signature
+    const derSig = signDer(sighash, key1.priv);
+
+    // Witness: [dummy, 1 sig, witnessScript] — only 1 sig instead of 2
+    const stack = [Buffer.alloc(0), derSig, witnessScript];
+    const signatureBase64 = encodeWitnessStack(stack).toString('base64');
+
+    expect(verifyBip322P2wshSignature(message, address, signatureBase64)).toBe(false);
+  });
+
+  it('rejects wrong message', () => {
+    const { address, signatureBase64 } = signMultisig(message, keys, [0, 1]);
+    expect(verifyBip322P2wshSignature('wrong message', address, signatureBase64)).toBe(false);
+  });
+
+  it('rejects signature with foreign key', () => {
+    const foreignKey = generateKey();
+    const pubkeys = keys.map((k) => k.pub);
+    const witnessScript = buildSortedMultisigScript(pubkeys, 2);
+    const address = p2wshAddress(witnessScript);
+    const sighash = computeSighash(message, witnessScript);
+
+    const sorted = [...pubkeys].sort(Buffer.compare);
+
+    // Sign with key1 (valid) and foreignKey (not in script)
+    const sig1 = signDer(sighash, key1.priv);
+    const sig2 = signDer(sighash, foreignKey.priv);
+
+    // Order: sig for key1 first (by sorted position), then foreign sig
+    const idx1 = sorted.findIndex((s) => s.equals(key1.pub));
+    const sigs = idx1 === 0 ? [sig1, sig2] : [sig2, sig1];
+
+    const stack = [Buffer.alloc(0), ...sigs, witnessScript];
+    const signatureBase64 = encodeWitnessStack(stack).toString('base64');
+
+    expect(verifyBip322P2wshSignature(message, address, signatureBase64)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: real wallet fixture (placeholder)
+// ---------------------------------------------------------------------------
+
+describe('verifyBip322P2wshSignature — real wallet fixture', () => {
+  it.todo('verify a signature produced by a real hardware wallet');
+});

--- a/packages/bip322-multisig/src/__tests__/verify.test.ts
+++ b/packages/bip322-multisig/src/__tests__/verify.test.ts
@@ -1,13 +1,7 @@
 import { Transaction } from 'bitcoinjs-lib';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { isP2wshAddress, verifyBip322P2wshSignature } from '../verify';
-import {
-  buildSortedMultisigScript,
-  p2wshAddress,
-  p2wshScriptPubKey,
-  bip322MessageHash,
-  buildToSpendTx,
-} from '../core';
+import { buildSortedMultisigScript, p2wshAddress, p2wshScriptPubKey, bip322MessageHash, buildToSpendTx } from '../core';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -107,9 +101,7 @@ function signMultisig(
 
 describe('isP2wshAddress', () => {
   it('accepts a valid mainnet P2WSH address', () => {
-    expect(
-      isP2wshAddress('bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep'),
-    ).toBe(true);
+    expect(isP2wshAddress('bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep')).toBe(true);
   });
 
   it('rejects a P2WPKH address (20-byte program)', () => {
@@ -121,11 +113,7 @@ describe('isP2wshAddress', () => {
   });
 
   it('rejects a testnet P2WSH address', () => {
-    expect(
-      isP2wshAddress(
-        'tb1qrp33g0q5b5698ahp5jnf5yzjmgced69zxx0pehrqcgul8ntf0t4qnmva5v',
-      ),
-    ).toBe(false);
+    expect(isP2wshAddress('tb1qrp33g0q5b5698ahp5jnf5yzjmgced69zxx0pehrqcgul8ntf0t4qnmva5v')).toBe(false);
   });
 
   it('rejects a malformed string', () => {
@@ -144,32 +132,18 @@ describe('isP2wshAddress', () => {
 describe('verifyBip322P2wshSignature — structural negatives', () => {
   it('returns false for empty signature', () => {
     expect(
-      verifyBip322P2wshSignature(
-        'hello',
-        'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep',
-        '',
-      ),
+      verifyBip322P2wshSignature('hello', 'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep', ''),
     ).toBe(false);
   });
 
   it('returns false for garbage base64', () => {
     expect(
-      verifyBip322P2wshSignature(
-        'hello',
-        'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep',
-        'AAAA',
-      ),
+      verifyBip322P2wshSignature('hello', 'bc1qsy93ywfzzp4e8aczvzn4452jmlwvyp2fklnm2qevnyzlmyd672pqrl3cep', 'AAAA'),
     ).toBe(false);
   });
 
   it('returns false for non-P2WSH address', () => {
-    expect(
-      verifyBip322P2wshSignature(
-        'hello',
-        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-        'AAAA',
-      ),
-    ).toBe(false);
+    expect(verifyBip322P2wshSignature('hello', 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'AAAA')).toBe(false);
   });
 });
 

--- a/packages/bip322-multisig/src/index.ts
+++ b/packages/bip322-multisig/src/index.ts
@@ -16,3 +16,6 @@ export type { DescriptorKey, MultisigDescriptor, DerivedAddress } from './descri
 
 export { buildBip322Psbt } from './psbt';
 export type { BuildPsbtArgs, BuiltPsbt } from './psbt';
+
+// Verification
+export { isP2wshAddress, verifyBip322P2wshSignature } from './verify';

--- a/packages/bip322-multisig/src/verify.ts
+++ b/packages/bip322-multisig/src/verify.ts
@@ -183,11 +183,7 @@ function parseMultisigScript(script: Buffer): MultisigInfo | null {
  * @param signatureBase64 The base64-encoded witness stack
  * @returns true when the signature is valid
  */
-export function verifyBip322P2wshSignature(
-  message: string,
-  address: string,
-  signatureBase64: string,
-): boolean {
+export function verifyBip322P2wshSignature(message: string, address: string, signatureBase64: string): boolean {
   try {
     // 1. Decode address -> 32-byte witness program
     if (!isP2wshAddress(address)) return false;
@@ -226,12 +222,7 @@ export function verifyBip322P2wshSignature(
     toSign.addInput(toSpend.getHash(), 0, 0);
     toSign.addOutput(Buffer.from([0x6a]), 0);
 
-    const sighash = toSign.hashForWitnessV0(
-      0,
-      witnessScript,
-      0,
-      Transaction.SIGHASH_ALL,
-    );
+    const sighash = toSign.hashForWitnessV0(0, witnessScript, 0, Transaction.SIGHASH_ALL);
 
     // 8. Verify multisig (OP_CHECKMULTISIG convention)
     let pkIdx = 0;

--- a/packages/bip322-multisig/src/verify.ts
+++ b/packages/bip322-multisig/src/verify.ts
@@ -1,0 +1,268 @@
+/**
+ * BIP-322 P2WSH signature verification.
+ *
+ * Verifies BIP-322 "simple" signatures produced by P2WSH multisig wallets.
+ */
+import { Transaction, crypto as btcCrypto } from 'bitcoinjs-lib';
+import { bech32 } from 'bech32';
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import { bip322MessageHash, buildToSpendTx, p2wshScriptPubKey } from './core';
+
+// ---------------------------------------------------------------------------
+// Address validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `address` is a mainnet P2WSH bech32 address
+ * (bc1q..., 62 characters, witness version 0, 32-byte program).
+ */
+export function isP2wshAddress(address: string): boolean {
+  if (typeof address !== 'string') return false;
+  try {
+    const decoded = bech32.decode(address);
+    if (decoded.prefix !== 'bc') return false;
+    const words = decoded.words;
+    if (words.length === 0) return false;
+    const witnessVersion = words[0];
+    if (witnessVersion !== 0) return false;
+    const program = Buffer.from(bech32.fromWords(words.slice(1)));
+    return program.length === 32;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Witness stack decoding
+// ---------------------------------------------------------------------------
+
+function decodeWitnessStack(buf: Buffer): Buffer[] {
+  let offset = 0;
+
+  function readVarint(): number {
+    const first = buf[offset++];
+    if (first < 0xfd) return first;
+    if (first === 0xfd) {
+      const v = buf.readUInt16LE(offset);
+      offset += 2;
+      return v;
+    }
+    if (first === 0xfe) {
+      const v = buf.readUInt32LE(offset);
+      offset += 4;
+      return v;
+    }
+    // 0xff — 8-byte; unlikely for witness but handle gracefully
+    const lo = buf.readUInt32LE(offset);
+    offset += 4;
+    const hi = buf.readUInt32LE(offset);
+    offset += 4;
+    return hi * 0x100000000 + lo;
+  }
+
+  const itemCount = readVarint();
+  const items: Buffer[] = [];
+  for (let i = 0; i < itemCount; i++) {
+    const len = readVarint();
+    items.push(buf.subarray(offset, offset + len));
+    offset += len;
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// DER signature parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a DER-encoded ECDSA signature into a compact 64-byte (r || s) Buffer.
+ * Accepts both low-S and high-S; noble/curves verify handles normalization.
+ */
+function parseDerSignature(der: Buffer): Buffer | null {
+  // DER: 0x30 <total-len> 0x02 <r-len> <r> 0x02 <s-len> <s>
+  if (der.length < 8) return null;
+  if (der[0] !== 0x30) return null;
+
+  let offset = 2; // skip 0x30 and length byte
+
+  // Parse R
+  if (der[offset] !== 0x02) return null;
+  offset++;
+  const rLen = der[offset++];
+  if (offset + rLen > der.length) return null;
+  const rRaw = der.subarray(offset, offset + rLen);
+  offset += rLen;
+
+  // Parse S
+  if (der[offset] !== 0x02) return null;
+  offset++;
+  const sLen = der[offset++];
+  if (offset + sLen > der.length) return null;
+  const sRaw = der.subarray(offset, offset + sLen);
+
+  // Convert to 32-byte big-endian, stripping leading zero padding
+  const r = padTo32(rRaw);
+  const s = padTo32(sRaw);
+  if (!r || !s) return null;
+
+  // Return compact 64-byte signature (r || s)
+  return Buffer.concat([r, s]);
+}
+
+function padTo32(buf: Buffer): Buffer | null {
+  // Strip leading zeros
+  let start = 0;
+  while (start < buf.length - 1 && buf[start] === 0) start++;
+  const trimmed = buf.subarray(start);
+  if (trimmed.length > 32) return null;
+  if (trimmed.length === 32) return Buffer.from(trimmed);
+  const padded = Buffer.alloc(32);
+  trimmed.copy(padded, 32 - trimmed.length);
+  return padded;
+}
+
+// ---------------------------------------------------------------------------
+// Multisig script parsing
+// ---------------------------------------------------------------------------
+
+interface MultisigInfo {
+  m: number;
+  n: number;
+  pubkeys: Buffer[];
+}
+
+function parseMultisigScript(script: Buffer): MultisigInfo | null {
+  if (script.length < 1) return null;
+
+  const first = script[0];
+  if (first < 0x51 || first > 0x60) return null; // OP_1..OP_16
+  const m = first - 0x50;
+
+  let offset = 1;
+  const pubkeys: Buffer[] = [];
+
+  while (offset < script.length) {
+    const op = script[offset];
+    if (op === 0x21) {
+      // PUSH 33 bytes (compressed pubkey)
+      offset += 1;
+      if (offset + 33 > script.length) return null;
+      const pk = script.subarray(offset, offset + 33);
+      if (pk[0] !== 0x02 && pk[0] !== 0x03) return null;
+      pubkeys.push(Buffer.from(pk));
+      offset += 33;
+    } else {
+      break;
+    }
+  }
+
+  if (offset + 2 > script.length) return null;
+  const nOp = script[offset];
+  if (nOp < 0x51 || nOp > 0x60) return null;
+  const n = nOp - 0x50;
+
+  if (script[offset + 1] !== 0xae) return null; // OP_CHECKMULTISIG
+  if (offset + 2 !== script.length) return null;
+
+  if (pubkeys.length !== n) return null;
+  if (m > n) return null;
+
+  return { m, n, pubkeys };
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a BIP-322 "simple" signature produced by a P2WSH multisig wallet.
+ *
+ * @param message         The signed message (UTF-8 string)
+ * @param address         A mainnet P2WSH address (bc1q...)
+ * @param signatureBase64 The base64-encoded witness stack
+ * @returns true when the signature is valid
+ */
+export function verifyBip322P2wshSignature(
+  message: string,
+  address: string,
+  signatureBase64: string,
+): boolean {
+  try {
+    // 1. Decode address -> 32-byte witness program
+    if (!isP2wshAddress(address)) return false;
+    const decoded = bech32.decode(address);
+    const program = Buffer.from(bech32.fromWords(decoded.words.slice(1)));
+
+    // 2. Decode base64 -> witness stack
+    const witnessBuf = Buffer.from(signatureBase64, 'base64');
+    const stack = decodeWitnessStack(witnessBuf);
+    if (stack.length < 3) return false; // at least: dummy, 1 sig, witnessScript
+
+    // 3. Last item = witnessScript; verify SHA256 matches program
+    const witnessScript = stack[stack.length - 1];
+    const scriptHash = btcCrypto.sha256(witnessScript);
+    if (!scriptHash.equals(program)) return false;
+
+    // 4. Parse multisig script
+    const info = parseMultisigScript(witnessScript);
+    if (!info) return false;
+
+    // 5. First item must be empty (OP_0 dummy for CHECKMULTISIG)
+    if (stack[0].length !== 0) return false;
+
+    // 6. Signature count must equal m
+    const sigs = stack.slice(1, stack.length - 1);
+    if (sigs.length !== info.m) return false;
+
+    // 7. Compute BIP-143 sighash
+    const scriptPubKey = p2wshScriptPubKey(witnessScript);
+    const messageHash = bip322MessageHash(message);
+    const toSpend = buildToSpendTx(messageHash, scriptPubKey);
+
+    const toSign = new Transaction();
+    toSign.version = 0;
+    toSign.locktime = 0;
+    toSign.addInput(toSpend.getHash(), 0, 0);
+    toSign.addOutput(Buffer.from([0x6a]), 0);
+
+    const sighash = toSign.hashForWitnessV0(
+      0,
+      witnessScript,
+      0,
+      Transaction.SIGHASH_ALL,
+    );
+
+    // 8. Verify multisig (OP_CHECKMULTISIG convention)
+    let pkIdx = 0;
+    for (const sigBuf of sigs) {
+      if (sigBuf.length < 1) return false;
+
+      // Last byte is sighash type
+      const sighashType = sigBuf[sigBuf.length - 1];
+      if (sighashType !== Transaction.SIGHASH_ALL) return false;
+
+      const derBytes = sigBuf.subarray(0, sigBuf.length - 1);
+
+      // Parse DER into compact (r||s) with low-S normalization
+      const compactSig = parseDerSignature(Buffer.from(derBytes));
+      if (!compactSig) return false;
+
+      // Find a matching pubkey (must be in order)
+      let matched = false;
+      while (pkIdx < info.pubkeys.length) {
+        const pk = info.pubkeys[pkIdx];
+        pkIdx++;
+        if (secp256k1.verify(compactSig, sighash, pk, { lowS: false })) {
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/bip322-multisig/src/verify.ts
+++ b/packages/bip322-multisig/src/verify.ts
@@ -68,6 +68,7 @@ function decodeWitnessStack(buf: Buffer): Buffer[] {
     items.push(buf.subarray(offset, offset + len));
     offset += len;
   }
+  if (offset !== buf.length) return [];
   return items;
 }
 

--- a/packages/bip322-multisig/tsconfig.build.json
+++ b/packages/bip322-multisig/tsconfig.build.json
@@ -6,6 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "module": "commonjs",
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Context

The `@dfx.swiss/bip322-multisig` package currently only provides building and signing primitives (`bip322MessageHash`, `buildToSpendTx`, `buildToSignPsbt`, `extractBip322Signature`, etc.). It has no verification capability.

In [DFXswiss/api#3637](https://github.com/DFXswiss/api/pull/3637), we added BIP-322 P2WSH multisig auth support. The verification logic currently lives as a standalone `bip322-p2wsh.util.ts` file in the API repo (~190 lines). [Review feedback](https://github.com/DFXswiss/api/pull/3637#discussion_r3168506043) asks to remove that file and use this package instead.

This PR adds the missing verification functions so the API can replace the custom util file with a single package import.

## Changes

New module `src/verify.ts` exporting:

- **`isP2wshAddress(address)`** — mainnet P2WSH bech32 address detection (witness v0, 32-byte program)
- **`verifyBip322P2wshSignature(message, address, signatureBase64)`** — full BIP-322 simple signature verification for standard P2WSH multisig (`OP_M ... OP_N OP_CHECKMULTISIG`)

Internally uses existing `core.ts` primitives (`bip322MessageHash`, `buildToSpendTx`, `p2wshScriptPubKey`) + `bitcoinjs-lib` `Transaction.hashForWitnessV0` for sighash computation. ECDSA verification via `@noble/curves/secp256k1`.

New dependency: `@noble/curves@^2.2.0`

## Tests

16 tests in `src/__tests__/verify.test.ts`:
- 6× address validation (mainnet P2WSH, P2WPKH, legacy, testnet, malformed, empty)
- 3× structural negatives (empty sig, garbage base64, wrong address type)
- 3× synthetic 2-of-3 sortedmulti roundtrip sign+verify
- 3× rejection (under-threshold, wrong message, foreign key)
- 1× todo placeholder for real wallet fixture