### PR TITLE
feat(core): add Monitoring user role

### DIFF
--- a/packages/core/src/definitions/jwt.ts
+++ b/packages/core/src/definitions/jwt.ts
@@ -12,6 +12,7 @@ export enum UserRole {
   CUSTODY = 'Custody',
   REALUNIT = 'RealUnit',
   MARKETING = 'Marketing',
+  MONITORING = 'Monitoring',
 }
 
 export interface Jwt {


### PR DESCRIPTION
## Summary

Adds a new `MONITORING` value to the `UserRole` enum in `@dfx.swiss/core`. This is phase 1 of a backend read-only role that grants view-only access to monitoring endpoints. Follow-up PRs in `api` and `services` will wire up the actual route guards and UI gating.

## Changes

- `packages/core/src/definitions/jwt.ts`: append `MONITORING = 'Monitoring'` to `UserRole` (re-exported through `@dfx.swiss/react`).

## Notes

- Additive enum extension, no breaking changes.
- No manual version bump: the publish workflow (`lerna version --conventional-commits --conventional-prerelease`) handles the beta bump automatically on merge into `develop`, in line with prior feature PRs (#144, #162, #176).