### PR TITLE
feat(core,react): add PARTNER role + /partner URL constants and types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@dfx.swiss/core",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -137,6 +137,8 @@ export type {
   AssignPaymentLink,
   PaymentLinkPos,
 } from './route';
+export { PartnerUrl } from './partner';
+export type { PartnerUserInfo, PartnerFee, SetOnboardingFee } from './partner';
 export { SellUrl } from './sell';
 export type { Eip5792Call, Eip5792Data, UnsignedTx, Sell, Beneficiary, SellPaymentInfo, ConfirmSellData } from './sell';
 export type { Session } from './session';

--- a/packages/core/src/definitions/jwt.ts
+++ b/packages/core/src/definitions/jwt.ts
@@ -11,6 +11,7 @@ export enum UserRole {
   KYC_CLIENT_COMPANY = 'KycClientCompany',
   CUSTODY = 'Custody',
   REALUNIT = 'RealUnit',
+  PARTNER = 'Partner',
   MARKETING = 'Marketing',
   MONITORING = 'Monitoring',
 }

--- a/packages/core/src/definitions/partner.ts
+++ b/packages/core/src/definitions/partner.ts
@@ -1,0 +1,30 @@
+export const PartnerUrl = {
+  getUser: (address: string) => `partner/user?address=${encodeURIComponent(address)}`,
+  listUsers: 'partner/users',
+  listFees: 'partner/fees',
+  setOnboarding: (userDataId: number) => `partner/user/${userDataId}/onboarding`,
+  removeFee: (userDataId: number, feeId: number) => `partner/user/${userDataId}/fee?fee=${feeId}`,
+};
+
+export interface PartnerUserInfo {
+  id: number;
+  status: string;
+  mail?: string;
+  firstname?: string;
+  surname?: string;
+  usedRef: string;
+  feeIds: number[];
+  canModify: boolean;
+}
+
+export interface PartnerFee {
+  id: number;
+  label: string;
+  type: string;
+  rate: number;
+  fixed: number;
+}
+
+export interface SetOnboardingFee {
+  feeId: number;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,8 @@ export {
   PaymentQuoteStatus,
   MinCompletionStatus,
   PaymentLinkBlockchain,
+  // Partner
+  PartnerUrl,
   // Sell
   SellUrl,
   // Settings
@@ -213,6 +215,10 @@ export type {
   UpdatePaymentLink,
   AssignPaymentLink,
   PaymentLinkPos,
+  // Partner
+  PartnerUserInfo,
+  PartnerFee,
+  SetOnboardingFee,
   // Sell
   Eip5792Call,
   Eip5792Data,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@dfx.swiss/react",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@dfx.swiss/core": "^0.3.0-beta.1",
+    "@dfx.swiss/core": "^0.3.0-beta.2",
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "typescript": "^4.9.3"

--- a/packages/react/src/definitions/partner.ts
+++ b/packages/react/src/definitions/partner.ts
@@ -1,0 +1,2 @@
+export { PartnerUrl } from '@dfx.swiss/core';
+export type { PartnerUserInfo, PartnerFee, SetOnboardingFee } from '@dfx.swiss/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -156,6 +156,8 @@ export {
   isStepDone,
   buildKycUrl,
 } from './definitions/kyc';
+export { PartnerUrl } from './definitions/partner';
+export type { PartnerUserInfo, PartnerFee, SetOnboardingFee } from './definitions/partner';
 export {
   Sell,
   SellPaymentInfo,


### PR DESCRIPTION
## Summary
- `packages/core`: `PARTNER = 'Partner'` added to `UserRole` enum
- `packages/core`: new `partner.ts` with `PartnerUrl` helper + `PartnerUserInfo`, `PartnerFee`, `SetOnboardingFee` types
- `packages/react`: thin re-exports from `@dfx.swiss/core`
- Version bumps: `core` 0.3.0-beta.1 → 0.3.0-beta.2, `react` 1.4.0-beta.1 → 1.4.0-beta.2

## Why
Mirrors the new `/partner` endpoint family added in [DFXswiss/api#3787](https://github.com/DFXswiss/api/pull/3787). The `DFXswiss/services` UI PR will consume `PartnerUrl` and the `PartnerUserInfo`/`PartnerFee` types via `@dfx.swiss/react`.

## Test plan
- [x] core: `npm run build`, `npm run lint`, `npm run format:check`, `npm test` (54 passed)
- [x] react: `npm run build`, `npm run lint`, `npm run format:check`
- [ ] After merge: Publish-workflow ships both packages via OIDC
- [ ] `DFXswiss/services` PR bumps dep to `^1.4.0-beta.2` and uses the new exports