### PR TITLE
fix(core,react): only send x-kyc-code to the configured API origin

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -127,4 +127,28 @@ describe('Utils', () => {
       expect(result.field).toEqual({ required: true, minLength: 3 });
     });
   });
+
+  describe('isSameOrigin', () => {
+    const base = 'https://api.dfx.swiss/v2';
+
+    it('accepts a URL on the same origin', () => {
+      expect(Utils.isSameOrigin('https://api.dfx.swiss/v2/kyc/data/personal/123', base)).toBe(true);
+      expect(Utils.isSameOrigin('https://api.dfx.swiss/anything', base)).toBe(true);
+    });
+
+    it('rejects a different host', () => {
+      expect(Utils.isSameOrigin('https://evil.example/v2/kyc', base)).toBe(false);
+      expect(Utils.isSameOrigin('https://api.dfx.swiss.evil.example/v2/kyc', base)).toBe(false);
+    });
+
+    it('rejects a different scheme or port', () => {
+      expect(Utils.isSameOrigin('http://api.dfx.swiss/v2/kyc', base)).toBe(false);
+      expect(Utils.isSameOrigin('https://api.dfx.swiss:8443/v2/kyc', base)).toBe(false);
+    });
+
+    it('fails closed on unparsable input', () => {
+      expect(Utils.isSameOrigin('not a url', base)).toBe(false);
+      expect(Utils.isSameOrigin('', base)).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/client/KycApi.ts
+++ b/packages/core/src/client/KycApi.ts
@@ -205,6 +205,12 @@ export class KycApi {
     code: string,
     config: { url: string; method: 'GET' | 'PUT' | 'POST' | 'DELETE'; data?: any; noJson?: boolean },
   ): Promise<T> {
+    // Several setters take the target URL from a previous step response. Never send the x-kyc-code
+    // credential to anything but the configured API origin, so a tampered step URL cannot exfiltrate it.
+    if (!Utils.isSameOrigin(config.url, this.http.getBaseUrl())) {
+      throw new Error('Refusing to send KYC credentials to a non-API origin');
+    }
+
     return this.http.requestAbsolute<T>({
       ...config,
       token: false,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -75,4 +75,15 @@ export class Utils {
       reader.onerror = (e) => reject(e);
     });
   }
+
+  // True only when `url` targets the exact same origin as `baseUrl`. Used to guard credentialed
+  // requests (e.g. the x-kyc-code header) against being sent to a foreign origin if a step URL ever
+  // came from an untrusted source. Unparsable input fails closed.
+  static isSameOrigin(url: string, baseUrl: string): boolean {
+    try {
+      return new URL(url).origin === new URL(baseUrl).origin;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/packages/react/src/hooks/kyc.hook.ts
+++ b/packages/react/src/hooks/kyc.hook.ts
@@ -30,6 +30,7 @@ import {
   KycChangeNameData,
   KycChangePhoneData,
 } from '../definitions/kyc';
+import { Utils } from '../utils';
 import { useApi } from './api.hook';
 
 export interface CallConfig {
@@ -105,6 +106,12 @@ export function useKyc(): KycInterface {
 
   const call = useCallback(
     async <T>(config: CallConfig): Promise<T> => {
+      // Never send the x-kyc-code credential anywhere but the configured API origin: some setters
+      // take their URL from a previous step response, so a tampered URL must not exfiltrate it.
+      if (!Utils.isSameOrigin(config.url, defaultUrl)) {
+        throw new Error('Refusing to send KYC credentials to a non-API origin');
+      }
+
       return fetch(config.url, buildInit(config)).then((response) => {
         if (response.ok) {
           return response.json().catch(() => undefined);
@@ -114,7 +121,7 @@ export function useKyc(): KycInterface {
         });
       });
     },
-    [buildInit],
+    [buildInit, defaultUrl],
   );
 
   const setName = useCallback(


### PR DESCRIPTION
## Finding (Medium, branch-weiter Security-Review)

Die KYC-Setter (`setContactData`, `setPersonalData`, `setNationalityData`, … ~20 Stück) nehmen ihre Ziel-URL aus der vorherigen Step-Antwort der API und reichen sie direkt an den credentialed Request weiter, der den `x-kyc-code`-Header (KYC-Auth-Token) trägt:
- **core:** `KycApi.kycRequest` → `http.requestAbsolute` mit `headers: { 'x-kyc-code': code }`
- **react:** `useKyc`'s `call` → `fetch(config.url, …)` mit `x-kyc-code`

Keine der beiden Stellen prüfte, dass die URL auf der API-Origin bleibt. Eine manipulierte / via MITM veränderte Step-URL könnte den KYC-Code an einen fremden Host exfiltrieren. Als Bibliothek multipliziert sich der Fehler über alle Konsumenten (Threat-Model: Fehlerquelle, die kein Konsument selbst absichern kann).

## Fix

Neuer Helper `Utils.isSameOrigin(url, baseUrl)` (core; im react-Paket via Re-Export verfügbar). Beide Call-Sites guarden: Requests an etwas anderes als die konfigurierte API-Origin werden abgelehnt, **bevor** der Header gesetzt wird. Fail-closed bei nicht-parsebaren URLs.

Vergleich auf exakte Origin (Scheme + Host + Port) gegen `http.getBaseUrl()` (core) bzw. `defaultUrl` (react).

## Tests

`isSameOrigin`-Spec (core): same-origin ✓, fremder Host / Subdomain-Trick / abweichendes Scheme/Port → abgewiesen, unparsebar → false. core 58/58 grün; core+react Build und Lint sauber.

Letzter offener Punkt aus dem Security-Backlog. Verbleibend nur noch der Account-Merge Token-Bindungs-Designentscheid (David).