### PR TITLE
feat(core): add phoneCallTimes to CallQueueItem

### DIFF
--- a/packages/core/src/definitions/compliance.ts
+++ b/packages/core/src/definitions/compliance.ts
@@ -60,6 +60,7 @@ export interface CallQueueItem {
   ip?: string;
   ipCountry?: string;
   phoneCallStatus?: PhoneCallStatus;
+  phoneCallTimes?: string;
   date: string;
 }
 


### PR DESCRIPTION
## Was
Ergänzt das `CallQueueItem`-Interface in `@dfx.swiss/core` um `phoneCallTimes?: string`.

## Warum
Das Compliance-Tool (`DFXswiss/services`) soll die vom Kunden gewählte bevorzugte Anrufzeit in der Call-Queue-Übersicht anzeigen. Die API liefert das Feld bereits (gekoppelter PR), hier wird nur der gemeinsame Typ nachgezogen.

## Hinweis Release
`develop`-Merge triggert per CI automatisch `lerna version --conventional-prerelease` + publish (neue Beta). Daher Conventional-Commit `feat(core): …` → korrekter Beta-Bump. **Keine manuelle Versionsänderung** im PR.

## Gekoppelte PRs
- API: DFXswiss/api#3924
- Frontend: DFXswiss/services#1126 (zieht nach diesem Publish die neue Beta)