### PR TITLE
Migrate publish workflow to npm OIDC (Trusted Publisher)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - develop
       - main
+  # allow re-triggering a publish manually (e.g. after a transient npm/auth failure) without a new commit
+  workflow_dispatch:
 
 env:
   NODE_VERSION: "18.x"
@@ -43,7 +45,9 @@ jobs:
           git config user.email "info@dfx.swiss"
 
           npx lerna version --conventional-commits --conventional-prerelease --preid beta --yes
-          npx lerna publish from-git --yes --dist-tag beta
+          # from-package (not from-git) so a re-run/dispatch publishes any package.json version missing from
+          # the registry, even when no tag sits on the checked-out commit (recovers a partially-failed publish)
+          npx lerna publish from-package --yes --dist-tag beta
 
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
@@ -54,7 +58,8 @@ jobs:
           git config user.email "info@dfx.swiss"
 
           npx lerna version --conventional-commits --conventional-graduate --yes
-          npx lerna publish from-git --yes
+          # from-package so a re-run/dispatch can recover a partially-failed publish (see beta step)
+          npx lerna publish from-package --yes
 
       - name: "Sync main back to develop"
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,12 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: "18.x"
+  NODE_VERSION: "22.x"
 
 permissions:
   contents: write
+  # required for npm OIDC (Trusted Publisher) — replaces NODE_AUTH_TOKEN
+  id-token: write
 
 jobs:
   publish:
@@ -30,7 +32,7 @@ jobs:
 
       - name: Install packages
         run: |
-          npm install
+          npm ci
 
       - name: Build code
         run: |
@@ -39,7 +41,9 @@ jobs:
       - name: "Version and publish (beta)"
         if: github.ref == 'refs/heads/develop'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          # OIDC would auto-enable provenance, but existing versions on npm have none —
+          # disable explicitly so mixed-provenance publishes don't E404 (see #150/#151)
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"
@@ -52,7 +56,7 @@ jobs:
       - name: "Version and publish (stable)"
         if: github.ref == 'refs/heads/main'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
           git config user.name "DFX"
           git config user.email "info@dfx.swiss"


### PR DESCRIPTION
### Problem

The publish workflow has been broken since **2026-05-13** (issue #183): `NODE_AUTH_TOKEN` silently expired/lost scope access, causing `E404` on every publish. `npm` is stuck at `@dfx.swiss/core@0.3.0-beta.0` / `@dfx.swiss/react@1.4.0-beta.0`, while `develop` has advanced to `beta.2`. This blocks services PR https://github.com/DFXswiss/services/pull/1146.

Root causes:
1. **Auth**: token-based publishing is fragile — Publish tokens expire in ~30 days, Classic Automation tokens are no longer available on new npm accounts, and Granular tokens cap at 90 days for write access. Perpetual rotation treadmill.
2. **Recovery**: `lerna publish from-git` only publishes tags on the checked-out commit. A re-run after a partial failure publishes nothing and exits green — masking the outage (a manual re-run of #181 went "green" on 2026-07-01 while publishing nothing).

### Fix

Full migration to **npm OIDC (Trusted Publisher)** — no long-lived secrets, no expiry, verified per-workflow.

**Workflow changes** (`.github/workflows/publish.yaml`):
- add `id-token: write` permission for OIDC token exchange
- remove both `NODE_AUTH_TOKEN` env blocks — auth is now via OIDC
- set `NPM_CONFIG_PROVENANCE=false` explicitly to avoid mixed-provenance `E404` on packages whose historical versions were token-published without provenance (this was the failure mode diagnosed in #150/#151)
- bump `NODE_VERSION` 18 → 22 (Node 18 has been EOL since 2025-04-30)
- switch `npm install` → `npm ci` for reproducible CI installs
- `from-git` → `from-package` on both beta and stable publish steps, so a re-run/dispatch actually recovers missing versions from the registry
- add `workflow_dispatch` trigger so a stuck publish can be re-triggered without a new commit

### Required npm-side setup (do before merging)

Configure Trusted Publisher on each of the four packages:

- [x] `@dfx.swiss/react-components` — already configured
- [ ] `@dfx.swiss/core` — https://www.npmjs.com/package/@dfx.swiss/core/access
- [ ] `@dfx.swiss/react` — https://www.npmjs.com/package/@dfx.swiss/react/access
- [ ] `@dfx.swiss/bip322-multisig` — https://www.npmjs.com/package/@dfx.swiss/bip322-multisig/access

For each: Settings → Trusted Publisher →
- Repository owner: `DFXswiss`
- Repository name: `packages`
- Workflow filename: `publish.yaml`
- Environment: (blank)

### Post-merge

1. Trigger the workflow via `workflow_dispatch` on `develop`
2. **Verify against the registry**, not just the run status:
   ```
   npm view @dfx.swiss/core dist-tags       # expect beta: 0.3.0-beta.2
   npm view @dfx.swiss/react dist-tags      # expect beta: 1.4.0-beta.2
   ```
3. Delete the `NODE_AUTH_TOKEN` secret from repo settings (no longer used)

### Notes

- Provenance signing is intentionally disabled for now — the historical versions on npm were not signed, and re-enabling would `E404`. Enabling provenance is a follow-up (would require a coordinated first-time provenance publish).
- If the OIDC publish fails on the first run with an npm version error, add `npm install -g npm@latest` after the `setup-node` step. Node 22 ships with npm 10 which should be sufficient, but the exact requirement has shifted across npm releases.

Closes #183