### PR TITLE
Normalize URL joining in HTTP clients (strip duplicate slashes)

### DIFF
--- a/packages/core/src/__tests__/http-client.test.ts
+++ b/packages/core/src/__tests__/http-client.test.ts
@@ -66,6 +66,22 @@ describe('DfxHttpClient', () => {
       );
     });
 
+    it('normalizes a leading-slash path to a single-slash URL', async () => {
+      const mockFetch = createMockFetch({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({}),
+      });
+      const client = new DfxHttpClient({ apiUrl: 'https://api.dfx.swiss/v1', fetchFn: mockFetch as any });
+
+      await client.request({ url: '/realunit/admin/quotes', method: 'GET' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.dfx.swiss/v1/realunit/admin/quotes',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
     it('uses custom version', async () => {
       const mockFetch = createMockFetch({
         ok: true,

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -54,6 +54,46 @@ describe('Utils', () => {
     });
   });
 
+  describe('joinUrl', () => {
+    it('joins base and clean path with a single slash', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', 'asset')).toBe('https://api.dfx.swiss/v1/asset');
+    });
+
+    it('strips a leading slash from the path', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', '/realunit/admin/quotes')).toBe(
+        'https://api.dfx.swiss/v1/realunit/admin/quotes',
+      );
+    });
+
+    it('strips multiple leading slashes from the path', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', '///asset')).toBe('https://api.dfx.swiss/v1/asset');
+    });
+
+    it('strips a trailing slash from the base', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1/', 'asset')).toBe('https://api.dfx.swiss/v1/asset');
+    });
+
+    it('collapses slashes on both sides of the seam', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1//', '//asset')).toBe('https://api.dfx.swiss/v1/asset');
+    });
+
+    it('preserves query strings on the path', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', '/buy/quote?asset=BTC&amount=1')).toBe(
+        'https://api.dfx.swiss/v1/buy/quote?asset=BTC&amount=1',
+      );
+    });
+
+    it('returns an absolute http/https path unchanged', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', 'https://kyc.dfx.swiss/session/abc')).toBe(
+        'https://kyc.dfx.swiss/session/abc',
+      );
+    });
+
+    it('returns the trimmed base for an empty path', () => {
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1/', '')).toBe('https://api.dfx.swiss/v1');
+    });
+  });
+
   describe('formatAmount', () => {
     it('formats with default 2 decimals', () => {
       expect(Utils.formatAmount(1234.5678)).toBe('1 234.57');

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -83,9 +83,12 @@ describe('Utils', () => {
       );
     });
 
-    it('returns an absolute http/https path unchanged', () => {
-      expect(Utils.joinUrl('https://api.dfx.swiss/v1', 'https://kyc.dfx.swiss/session/abc')).toBe(
-        'https://kyc.dfx.swiss/session/abc',
+    it('joins an absolute path literally, keeping parity with plain concatenation', () => {
+      // Deliberate: request()/call() attach the bearer token, so an absolute config.url must
+      // stay a same-origin request (harmless 404) and never be sent to a foreign host.
+      // Absolute URLs belong to requestAbsolute().
+      expect(Utils.joinUrl('https://api.dfx.swiss/v1', 'https://evil.example.com/steal')).toBe(
+        'https://api.dfx.swiss/v1/https://evil.example.com/steal',
       );
     });
 

--- a/packages/core/src/client/DfxHttpClient.ts
+++ b/packages/core/src/client/DfxHttpClient.ts
@@ -1,4 +1,5 @@
 import { ApiError, ApiException } from '../definitions/error';
+import { Utils } from '../utils';
 
 export enum ResponseType {
   JSON = 'json',
@@ -51,8 +52,8 @@ export class DfxHttpClient {
    */
   async request<T>(config: RequestConfig): Promise<T> {
     const version = config.version ?? this.getDefaultVersion();
-    const baseUrl = `${this.getBaseUrl()}/${version}`;
-    return this.rawRequest<T>({ ...config, url: `${baseUrl}/${config.url}` });
+    const baseUrl = Utils.joinUrl(this.getBaseUrl(), version);
+    return this.rawRequest<T>({ ...config, url: Utils.joinUrl(baseUrl, config.url) });
   }
 
   /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -46,16 +46,18 @@ export class Utils {
   }
 
   /**
-   * Join a base URL with a relative path, collapsing any duplicate slashes at the seam.
+   * Join a base URL with a relative API path, collapsing any duplicate slashes at the seam.
    *
    * Trailing slashes on the base and leading slashes on the path are stripped before joining
    * with a single '/'. This prevents malformed URLs like `https://api.dfx.swiss/v1//foo` (which
    * the API rejects with a 404 before any route/guard runs) when a caller passes a leading-slash
-   * path such as '/foo'. Absolute paths (http/https) are returned unchanged, and query strings
-   * are preserved.
+   * path such as '/foo'. Query strings are preserved.
+   *
+   * This is pure seam normalization for relative paths: an absolute (http/https) path is joined
+   * literally like any other segment, exactly as plain concatenation did. Requests to absolute
+   * URLs belong to `DfxHttpClient.requestAbsolute()`.
    */
   static joinUrl(base: string, path: string): string {
-    if (/^https?:\/\//i.test(path)) return path;
     const trimmedBase = base.replace(/\/+$/, '');
     const trimmedPath = path.replace(/^\/+/, '');
     return trimmedPath ? `${trimmedBase}/${trimmedPath}` : trimmedBase;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -45,6 +45,22 @@ export class Utils {
     return jwt ? /^[A-Za-z0-9_-]{2,}(?:\.[A-Za-z0-9_-]{2,}){2}$/.test(jwt) : false;
   }
 
+  /**
+   * Join a base URL with a relative path, collapsing any duplicate slashes at the seam.
+   *
+   * Trailing slashes on the base and leading slashes on the path are stripped before joining
+   * with a single '/'. This prevents malformed URLs like `https://api.dfx.swiss/v1//foo` (which
+   * the API rejects with a 404 before any route/guard runs) when a caller passes a leading-slash
+   * path such as '/foo'. Absolute paths (http/https) are returned unchanged, and query strings
+   * are preserved.
+   */
+  static joinUrl(base: string, path: string): string {
+    if (/^https?:\/\//i.test(path)) return path;
+    const trimmedBase = base.replace(/\/+$/, '');
+    const trimmedPath = path.replace(/^\/+/, '');
+    return trimmedPath ? `${trimmedBase}/${trimmedPath}` : trimmedBase;
+  }
+
   static buildQueryParams(params: { [key: string]: string | number | undefined }): string {
     return Object.keys(params)
       .filter((key) => params[key] !== undefined)

--- a/packages/react/src/hooks/api.hook.ts
+++ b/packages/react/src/hooks/api.hook.ts
@@ -1,3 +1,4 @@
+import { Utils } from '@dfx.swiss/core';
 import { useCallback, useMemo } from 'react';
 import { useAuthContext } from '../contexts/auth.context';
 import { ApiError, ApiException } from '../definitions/error';
@@ -38,11 +39,11 @@ export function useApi(): ApiInterface {
   const fetchFrom = useCallback(
     async function <T>(config: CallConfig): Promise<T> {
       const version = config.version ?? defaultVersion;
-      const baseUrl = `${url}/${version}`;
+      const baseUrl = Utils.joinUrl(url, version);
       const responseType = config.responseType ?? ResponseType.JSON;
 
       return fetch(
-        `${baseUrl}/${config.url}`,
+        Utils.joinUrl(baseUrl, config.url),
         buildInit(config.method, config.token === false ? undefined : config.token, config.data, config.noJson),
       )
         .catch((error: unknown) => {
@@ -123,5 +124,5 @@ export function useApi(): ApiInterface {
     };
   }
 
-  return useMemo(() => ({ defaultUrl: `${url}/${defaultVersion}`, call }), [url, defaultVersion, call]);
+  return useMemo(() => ({ defaultUrl: Utils.joinUrl(url, defaultVersion), call }), [url, defaultVersion, call]);
 }


### PR DESCRIPTION
## Problem

When a caller passes an API path with a leading slash (e.g. `'/realunit/admin/quotes'`), the HTTP clients built the request URL by plain string concatenation:

```
`${baseUrl}/${config.url}` → https://api.dfx.swiss/v1//realunit/admin/quotes
```

The resulting double slash (`/v1//...`) makes the API reject the request with a **404 before any route match or auth guard runs**, which surfaces to callers as a silent empty/failed response rather than a meaningful error. This is the failure mode that surfaced in DFXswiss/services#1150.

The consumer-side misuse is being fixed in the services repo. This PR **hardens the SDK** so the entire bug class (leading-slash path → double-slash URL → masked 404) is impossible for every consumer, regardless of how they format their paths.

## Change

Introduce a single shared helper `Utils.joinUrl(base, path)` in `@dfx.swiss/core`:

- strips trailing slashes from the base segment,
- strips leading slashes from the path segment,
- joins them with exactly one `/`,
- preserves query strings.

Both HTTP clients now route their joins through it.

This is **pure seam normalization with no contract change**: for every input that produced a working URL before, the output is identical; only the duplicate slashes at the seam are collapsed. In particular, an absolute (`http`/`https`) `config.url` is deliberately **not** special-cased — it is joined literally, byte-for-byte as plain concatenation did (same-origin request, harmless 404). `request()`/`call()` attach the bearer token, so an absolute path must never start resolving against a foreign host; requests to absolute URLs remain the job of `DfxHttpClient.requestAbsolute()`. A test pins this non-behavior down.

### Join sites hardened

- `packages/core/src/client/DfxHttpClient.ts` — `request()` (base⋅version join and base⋅path join)
- `packages/react/src/hooks/api.hook.ts` — `useApi()` `fetchFrom` (base⋅version and base⋅path) and the memoized `defaultUrl`

`react` already depends on `@dfx.swiss/core` and re-exports `Utils`, so the helper lives in core and is reused directly in both packages (no duplication). The base⋅version joins were normalized too, so a trailing slash on a configured API URL can no longer produce a double slash either.

## Tests

- Unit tests for `Utils.joinUrl`: clean passthrough, leading slash, multiple leading slashes, trailing slash on base, slashes on both sides of the seam, query-string preservation, empty path, and literal joining of absolute paths (concatenation parity — the token must stay on the API origin).
- Regression test in `http-client.test.ts`: a request config with `url: '/realunit/admin/quotes'` now fetches `https://api.dfx.swiss/v1/realunit/admin/quotes` (single slash).

All core tests pass (63), both packages build, lint and Prettier are clean.

Reference: DFXswiss/services#1150 (the incident that surfaced this).
