### PR TITLE
feat: expose switchToCode on ApiException for merged-account redirects

### DIFF
--- a/packages/core/src/__tests__/error.test.ts
+++ b/packages/core/src/__tests__/error.test.ts
@@ -32,4 +32,14 @@ describe('ApiException', () => {
       }
     }
   });
+
+  it('carries switchToCode when provided', () => {
+    const error = new ApiException(401, 'User is merged', undefined, 'MASTER-CODE');
+    expect(error.switchToCode).toBe('MASTER-CODE');
+  });
+
+  it('leaves switchToCode undefined when not provided', () => {
+    const error = new ApiException(401, 'Unauthorized');
+    expect(error.switchToCode).toBeUndefined();
+  });
 });

--- a/packages/core/src/client/DfxHttpClient.ts
+++ b/packages/core/src/client/DfxHttpClient.ts
@@ -111,6 +111,7 @@ export class DfxHttpClient {
       body?.statusCode ?? response.status,
       body?.message ?? response.statusText ?? 'Unknown error',
       body?.code,
+      body?.switchToCode,
     );
   }
 

--- a/packages/core/src/definitions/error.ts
+++ b/packages/core/src/definitions/error.ts
@@ -10,6 +10,11 @@ export interface ApiError {
    * 'KYC_LEVEL_REQUIRED'). Absent for generic errors.
    */
   code?: string;
+  /**
+   * Code of the master account to redirect to when a request targets a merged
+   * account (HTTP 401). Absent otherwise.
+   */
+  switchToCode?: string;
 }
 
 export class ApiException extends Error implements ApiError {
@@ -17,6 +22,7 @@ export class ApiException extends Error implements ApiError {
     public readonly statusCode: number,
     message: string,
     public readonly code?: string,
+    public readonly switchToCode?: string,
   ) {
     super(message);
     this.name = 'ApiException';

--- a/packages/react/src/hooks/api.hook.ts
+++ b/packages/react/src/hooks/api.hook.ts
@@ -78,6 +78,7 @@ export function useApi(): ApiInterface {
                 body?.statusCode ?? response.status,
                 body?.message ?? response.statusText ?? 'Unknown error',
                 body?.code,
+                body?.switchToCode,
               );
             });
         });


### PR DESCRIPTION
## What
Adds an optional `switchToCode` field to `ApiError` / `ApiException` and passes it through from the response body in `useApi().call` (`api.hook.ts`).

## Why
The merged-account handling (DFXswiss/api#4092) returns HTTP 401 with a `MergedDto` carrying `switchToCode` (the master account's code). Today `useApi().call` throws a stripped `ApiException` that only keeps `statusCode`/`message`/`code`, discarding `switchToCode` — so a services consumer cannot redirect a merged account to its master code the way `kyc.screen` does (the KYC client throws the raw body). This exposes `switchToCode` on the thrown error so the mail-update flows can handle merged accounts consistently.

## Notes
- **Backward-compatible:** new optional interface field + optional 4th constructor param; existing 2-/3-arg call sites unchanged.
- **Prerequisite** for the DFXswiss/services companion PR to api#4092, which bumps `@dfx.swiss/react` to the version published from this change.
- Tests added in `@dfx.swiss/core` (`error.test.ts`).