### PR TITLE
fix(react): omit userAddress on transaction list without session address

### DIFF
--- a/packages/core/src/client/TransactionApi.ts
+++ b/packages/core/src/client/TransactionApi.ts
@@ -15,6 +15,10 @@ import { DfxHttpClient, ResponseType } from './DfxHttpClient';
 export class TransactionApi {
   constructor(private readonly http: DfxHttpClient) {}
 
+  /**
+   * List history for the authenticated subject (Bearer JWT required on the HTTP client).
+   * Optional `userAddress` filters to one wallet that must belong to the account.
+   */
   async list(userAddress?: string): Promise<Transaction[]> {
     const query = Utils.buildQuery({ userAddress });
     return this.http.request<Transaction[]>({ url: `${TransactionUrl.get}${query}`, method: 'GET' });

--- a/packages/core/src/definitions/transaction.ts
+++ b/packages/core/src/definitions/transaction.ts
@@ -216,6 +216,7 @@ export interface TransactionRefundData {
 }
 
 export interface TransactionHistoryQuery {
+  /** Optional wallet scope; must belong to the authenticated account when set. */
   userAddress?: string;
   from?: Date;
   to?: Date;

--- a/packages/react/src/hooks/transaction.hook.ts
+++ b/packages/react/src/hooks/transaction.hook.ts
@@ -57,7 +57,9 @@ export function useTransaction(): TransactionInterface {
   const getTransactions = useCallback(async (): Promise<Transaction[]> => {
     if (!session) throw new Error('No active session');
 
-    return call<Transaction[]>({ url: `${TransactionUrl.get}?userAddress=${session.address}`, method: 'GET' });
+    // API requires JWT; optional userAddress scopes to the session wallet (must belong to account).
+    const q = session.address ? `?userAddress=${encodeURIComponent(session.address)}` : '';
+    return call<Transaction[]>({ url: `${TransactionUrl.get}${q}`, method: 'GET' });
   }, [call, session]);
 
   const getDetailTransactions = useCallback(


### PR DESCRIPTION
## Summary

- Align `@dfx.swiss/react` transaction list with API history auth hardening.
- Do not send `userAddress=undefined` for account-level sessions; only pass an encoded wallet filter when `session.address` is set.
- Document ownership semantics on `TransactionApi.list`.

## Companion

Depends on / pairs with **DFXswiss/api** branch `fix/secure-transaction-history-auth` (list/export require JWT or CT API key).

## Test plan

- [ ] CI green
- [ ] Wallet session: list still scoped and authenticated
- [ ] Account/mail session without address: list succeeds with Bearer only