### PR TITLE
feat(core): add personal IBAN provider contract

### DIFF
--- a/packages/core/src/definitions/buy.ts
+++ b/packages/core/src/definitions/buy.ts
@@ -11,6 +11,10 @@ export const BuyUrl = {
   confirm: (txId: number) => `buy/paymentInfos/${txId}/confirm`,
 };
 
+export enum PersonalIbanProvider {
+  FRICK = 'frick',
+}
+
 export interface Buy {
   id: number;
   uid: string;
@@ -24,6 +28,8 @@ export interface Buy {
   iban?: string;
   bic: string;
   sepaInstant: boolean;
+  /** Bank name (e.g. for personal IBAN); optional for backward compatibility. */
+  bank?: string;
   routeId: number;
   remittanceInfo?: string;
   fees: Fees;
@@ -56,6 +62,8 @@ export interface BuyPaymentInfo {
   paymentMethod?: FiatPaymentMethod;
   externalTransactionId?: string;
   exactPrice?: boolean;
+  /** Explicit personal IBAN provider (e.g. frick). Fail-closed on the API. */
+  personalIbanProvider?: PersonalIbanProvider;
 }
 
 export interface PdfDocument {

--- a/packages/core/src/definitions/buy.ts
+++ b/packages/core/src/definitions/buy.ts
@@ -12,7 +12,7 @@ export const BuyUrl = {
 };
 
 export enum PersonalIbanProvider {
-  FRICK = 'frick',
+  FRICK = 'Frick',
 }
 
 export interface Buy {

--- a/packages/core/src/definitions/buy.ts
+++ b/packages/core/src/definitions/buy.ts
@@ -62,7 +62,10 @@ export interface BuyPaymentInfo {
   paymentMethod?: FiatPaymentMethod;
   externalTransactionId?: string;
   exactPrice?: boolean;
-  /** Explicit personal IBAN provider (e.g. frick). Fail-closed on the API. */
+  /**
+   * Explicit personal IBAN provider (e.g. PersonalIbanProvider.FRICK / "Frick").
+   * Fail-closed on the API.
+   */
   personalIbanProvider?: PersonalIbanProvider;
 }
 

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -22,7 +22,7 @@ export type { Bank } from './bank';
 export { BankAccountUrl } from './bank-account';
 export type { BankAccount } from './bank-account';
 export { Blockchain } from './blockchain';
-export { BuyUrl } from './buy';
+export { BuyUrl, PersonalIbanProvider } from './buy';
 export type { Buy, BuyPaymentInfo, PdfDocument } from './buy';
 export { CountryUrl } from './country';
 export type { Country } from './country';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export {
   Blockchain,
   // Buy
   BuyUrl,
+  PersonalIbanProvider,
   // Country
   CountryUrl,
   // Error

--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -1,2 +1,4 @@
-export { BuyUrl, PersonalIbanProvider } from '@dfx.swiss/core';
+export { BuyUrl } from '@dfx.swiss/core';
+/** Personal IBAN provider values accepted by buy payment-info requests. */
+export { PersonalIbanProvider } from '@dfx.swiss/core';
 export type { Buy, BuyPaymentInfo, PdfDocument } from '@dfx.swiss/core';

--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -1,2 +1,2 @@
-export { BuyUrl } from '@dfx.swiss/core';
+export { BuyUrl, PersonalIbanProvider } from '@dfx.swiss/core';
 export type { Buy, BuyPaymentInfo, PdfDocument } from '@dfx.swiss/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -51,7 +51,7 @@ export { Asset, AssetType, AssetCategory, AssetUrl } from './definitions/asset';
 export { BankAccount, BankAccountUrl } from './definitions/bank-account';
 export { Bank, BankUrl } from './definitions/bank';
 export { Blockchain } from './definitions/blockchain';
-export { Buy, BuyPaymentInfo, PdfDocument, BuyUrl } from './definitions/buy';
+export { Buy, BuyPaymentInfo, PdfDocument, BuyUrl, PersonalIbanProvider } from './definitions/buy';
 export { Country, CountryUrl } from './definitions/country';
 export { ApiError, ApiException } from './definitions/error';
 export { Fiat, FiatUrl } from './definitions/fiat';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -51,7 +51,9 @@ export { Asset, AssetType, AssetCategory, AssetUrl } from './definitions/asset';
 export { BankAccount, BankAccountUrl } from './definitions/bank-account';
 export { Bank, BankUrl } from './definitions/bank';
 export { Blockchain } from './definitions/blockchain';
-export { Buy, BuyPaymentInfo, PdfDocument, BuyUrl, PersonalIbanProvider } from './definitions/buy';
+export { Buy, BuyPaymentInfo, PdfDocument, BuyUrl } from './definitions/buy';
+/** Personal IBAN provider values accepted by buy payment-info requests. */
+export { PersonalIbanProvider } from './definitions/buy';
 export { Country, CountryUrl } from './definitions/country';
 export { ApiError, ApiException } from './definitions/error';
 export { Fiat, FiatUrl } from './definitions/fiat';


### PR DESCRIPTION
## Summary

- add the exported `PersonalIbanProvider.FRICK` contract
- expose `personalIbanProvider` on core and React buy payment-info requests
- re-export the new type through the public package entry points

## Validation

- `npm run build --workspaces --if-present`
- all four workspaces built successfully

## Related rollout

The consuming API implementation is DFXswiss/api#4384. Consumers should only request the provider after that API change has been deployed.
