### PR TITLE
fix(react): refresh the cached user after updateMail

### DIFF
--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -93,9 +93,15 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
 
   const updateMail = useCallback(
     async (mail: string): Promise<void> => {
-      return updateMailApi(mail);
+      // The endpoint answers with an empty body, so the refreshed user has to be fetched: without
+      // it the cached `user.mail` stays stale and callers keep re-submitting the same address.
+      setIsUserUpdating(true);
+      return updateMailApi(mail)
+        .then(() => getUser())
+        .then(setUser)
+        .finally(() => setIsUserUpdating(false));
     },
-    [updateMailApi],
+    [getUser, updateMailApi],
   );
 
   const verifyMail = useCallback(

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -97,11 +97,16 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
       // it the cached `user.mail` stays stale and callers keep re-submitting the same address.
       // A failing refresh must not reject the call — the mail is already changed at that point, and
       // reporting it as an error would send the caller back into exactly that re-submit loop.
+      // The previous object is kept when the address did not move: an update that is still pending
+      // mail verification answers 202 and leaves the stored address untouched, so handing out a
+      // fresh identity there would re-trigger effects that watch `user` and re-submit endlessly.
       setIsUserUpdating(true);
       return updateMailApi(mail)
         .then(() =>
           getUser()
-            .then(setUser)
+            .then((refreshed) =>
+              setUser((prev) => (refreshed && prev && refreshed.mail === prev.mail ? prev : refreshed)),
+            )
             .catch(() => undefined),
         )
         .finally(() => setIsUserUpdating(false));

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -105,7 +105,7 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
         .then(() =>
           getUser()
             .then((refreshed) =>
-              setUser((prev) => (refreshed && prev && refreshed.mail === prev.mail ? prev : refreshed)),
+              setUser((prev) => (refreshed && (!prev || refreshed.mail !== prev.mail) ? refreshed : prev)),
             )
             .catch(() => undefined),
         )

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -96,13 +96,14 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
       // The endpoint returns an empty body, so the refreshed user has to be fetched. The refresh is
       // best-effort, and keeps the previous object when the address did not move — a change pending
       // mail verification (202) leaves it untouched, and a fresh identity there would re-trigger
-      // effects that watch `user` and re-submit endlessly.
+      // effects that watch `user` and re-submit endlessly. A cleared state stays cleared: a refresh
+      // landing after a logout must not put the signed-out user back.
       setIsUserUpdating(true);
       return updateMailApi(mail)
         .then(() =>
           getUser()
             .then((refreshed) =>
-              setUser((prev) => (refreshed && (!prev || refreshed.mail !== prev.mail) ? refreshed : prev)),
+              setUser((prev) => (prev && refreshed && refreshed.mail !== prev.mail ? refreshed : prev)),
             )
             .catch(() => undefined),
         )

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -95,10 +95,15 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
     async (mail: string): Promise<void> => {
       // The endpoint answers with an empty body, so the refreshed user has to be fetched: without
       // it the cached `user.mail` stays stale and callers keep re-submitting the same address.
+      // A failing refresh must not reject the call — the mail is already changed at that point, and
+      // reporting it as an error would send the caller back into exactly that re-submit loop.
       setIsUserUpdating(true);
       return updateMailApi(mail)
-        .then(() => getUser())
-        .then(setUser)
+        .then(() =>
+          getUser()
+            .then(setUser)
+            .catch(() => undefined),
+        )
         .finally(() => setIsUserUpdating(false));
     },
     [getUser, updateMailApi],

--- a/packages/react/src/contexts/user.context.tsx
+++ b/packages/react/src/contexts/user.context.tsx
@@ -93,13 +93,10 @@ export function UserContextProvider(props: PropsWithChildren): JSX.Element {
 
   const updateMail = useCallback(
     async (mail: string): Promise<void> => {
-      // The endpoint answers with an empty body, so the refreshed user has to be fetched: without
-      // it the cached `user.mail` stays stale and callers keep re-submitting the same address.
-      // A failing refresh must not reject the call — the mail is already changed at that point, and
-      // reporting it as an error would send the caller back into exactly that re-submit loop.
-      // The previous object is kept when the address did not move: an update that is still pending
-      // mail verification answers 202 and leaves the stored address untouched, so handing out a
-      // fresh identity there would re-trigger effects that watch `user` and re-submit endlessly.
+      // The endpoint returns an empty body, so the refreshed user has to be fetched. The refresh is
+      // best-effort, and keeps the previous object when the address did not move — a change pending
+      // mail verification (202) leaves it untouched, and a fresh identity there would re-trigger
+      // effects that watch `user` and re-submit endlessly.
       setIsUserUpdating(true);
       return updateMailApi(mail)
         .then(() =>


### PR DESCRIPTION
## Problem

`updateMail` in `UserContextProvider` is a bare passthrough:

```ts
const updateMail = useCallback(
  async (mail: string): Promise<void> => {
    return updateMailApi(mail);
  },
  [updateMailApi],
);
```

Every sibling in the same file — `updateUser`, `verifyMail`, `renameAddress`, `updateCallSettings` — sets `isUserUpdating` and writes the returned user back into state. `updateMail` does neither, and because `PUT /v2/user/mail` answers with an empty body there is nothing to `setUser` from: the refreshed user has to be fetched.

Two consequences for consumers:

1. **The cached `user.mail` stays `null` after a successful update.** A screen that renders its email step on `user.mail == null` re-renders unchanged and the user submits the same address again. The API requires 2FA once an account carries a mail, so every re-submit comes back `403 TFA_REQUIRED`. In production this produced 1206 such 403s in 30 days against 19 successful sets.
2. **`isUserUpdating` never flips**, so a consumer passing it as `isLoading` to a submit button leaves that button enabled for the whole in-flight request, and a double click fires two concurrent `PUT`s.

Both were lost in #74, which replaced `changeMail` with `updateMail` here. `changeMail` delegated to `updateUser`, which set the flag and refreshed the user; the replacement (`return updateMailApi(mail);`) inherited neither. The downstream consumer switched over six days later in DFXswiss/services#473.

> Note: the first commit message in this PR cites `#473` for that provenance. That is the consumer-side PR in `DFXswiss/services`, not the change in this repo — the correct reference is #74, as stated above. Left uncorrected in the commit message because re-signing a pushed commit would require an amend and force-push.

## Change

`updateMail` now sets `isUserUpdating`, awaits the update, fetches the refreshed user into state, and clears the flag.

Two guards on that refresh, both added after review found the naive version unsafe:

- **The refresh is best-effort.** If `getUser()` fails — or resolves nothing, since an OK response whose body does not parse resolves `undefined` — the cached user is left as it was and the call still succeeds. The mail has already been changed server-side, so rejecting `updateMail` would present a success as an error and push the caller back into the re-submit loop this PR exists to remove. The result of the update itself still propagates, so a consumer catching `403 TFA_REQUIRED` is unaffected.
- **The previous user object is kept when the address did not move.** `PUT /v2/user/mail` only persists the address when the account has none; once one exists it answers `202` and holds the new address until the emailed code is verified — so the refetched user still carries the *old* address. A consumer whose effect watches the `user` object and compares it against a target address would then see a fresh identity with its condition still unmet, call `updateMail` again, and repeat: an unbounded loop that mails a new verification code every pass and invalidates the previous one. Returning the previous object when nothing changed makes that unreachable.

The signature stays `(mail: string) => Promise<void>`, so this is behaviour-compatible for existing callers; a caller that ignored the cache before simply gets a correct one now.

## Verification

`npx lerna run lint`, `format:check` and `build` all pass across the four packages.

No version bump or CHANGELOG entry: per CONTRIBUTING, releases are cut by the publish workflow and feature PRs must not hand-bump.

## Related

- Server-side counterpart: DFXswiss/api#4439 (an unchanged address no longer demands 2FA).
- Consumer-side fix that does not wait on this release: DFXswiss/services#1204, which also makes the mail-parameter effect case-insensitive so it cannot re-submit indefinitely.