### PR TITLE
8d2cc4b3 - Add job ticket API and React tracking hook

### DIFF
--- a/packages/core/src/__tests__/http-client.test.ts
+++ b/packages/core/src/__tests__/http-client.test.ts
@@ -66,6 +66,25 @@ describe('DfxHttpClient', () => {
       );
     });
 
+    it('treats 202 Accepted as success and returns the parsed JSON body', async () => {
+      const body = {
+        uid: 'J7f3a9c2e1b8d4a60',
+        group: 'AccountMerge',
+        status: 'Pending',
+        expectedSeconds: 65,
+      };
+      const mockFetch = createMockFetch({
+        ok: true,
+        status: 202,
+        json: jest.fn().mockResolvedValue(body),
+      });
+      const client = new DfxHttpClient({ apiUrl: 'https://api.dfx.swiss/v1', fetchFn: mockFetch as any });
+
+      const result = await client.request({ url: 'job/J7f3a9c2e1b8d4a60', method: 'GET' });
+
+      expect(result).toEqual(body);
+    });
+
     it('normalizes a leading-slash path to a single-slash URL', async () => {
       const mockFetch = createMockFetch({
         ok: true,

--- a/packages/core/src/__tests__/job.test.ts
+++ b/packages/core/src/__tests__/job.test.ts
@@ -1,0 +1,55 @@
+import { JobApi } from '../client/JobApi';
+import { DfxHttpClient } from '../client/DfxHttpClient';
+import { isJobFinished, Job, JobStatus } from '../definitions/job';
+
+function createMockHttpClient(response?: unknown) {
+  const requestMock = jest.fn().mockResolvedValue(response);
+
+  return {
+    request: requestMock,
+    requestAbsolute: jest.fn(),
+    getBaseUrl: jest.fn().mockReturnValue('https://api.dfx.swiss'),
+    getApiUrl: jest.fn().mockReturnValue('https://api.dfx.swiss/v1'),
+    setToken: jest.fn(),
+    getToken: jest.fn(),
+  } as unknown as DfxHttpClient & { request: jest.Mock };
+}
+
+describe('JobApi', () => {
+  describe('get', () => {
+    it('requests job by uid and resolves with the job payload', async () => {
+      const job: Job = {
+        uid: 'J7f3a9c2e1b8d4a60',
+        group: 'AccountMerge',
+        status: JobStatus.PENDING,
+        created: new Date('2026-07-30T08:12:44.000Z'),
+        expectedSeconds: 65,
+      };
+      const mockHttp = createMockHttpClient(job);
+      const api = new JobApi(mockHttp);
+
+      const result = await api.get(job.uid);
+
+      expect(result).toEqual(job);
+      expect(result.uid).toBe('J7f3a9c2e1b8d4a60');
+      expect(result.group).toBe('AccountMerge');
+      expect(result.status).toBe(JobStatus.PENDING);
+      expect(result.created).toEqual(new Date('2026-07-30T08:12:44.000Z'));
+      expect(result.expectedSeconds).toBe(65);
+      expect(mockHttp.request).toHaveBeenCalledTimes(1);
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'job/J7f3a9c2e1b8d4a60', method: 'GET' });
+    });
+  });
+});
+
+describe('isJobFinished', () => {
+  it.each([
+    [JobStatus.PENDING, false],
+    [JobStatus.PROCESSING, false],
+    [JobStatus.COMPLETE, true],
+    [JobStatus.FAILED, true],
+    [JobStatus.DEAD_LETTER, true],
+  ])('status %s → finished=%s', (status, expected) => {
+    expect(isJobFinished(status)).toBe(expected);
+  });
+});

--- a/packages/core/src/__tests__/job.test.ts
+++ b/packages/core/src/__tests__/job.test.ts
@@ -39,6 +39,28 @@ describe('JobApi', () => {
       expect(mockHttp.request).toHaveBeenCalledTimes(1);
       expect(mockHttp.request).toHaveBeenCalledWith({ url: 'job/J7f3a9c2e1b8d4a60', method: 'GET' });
     });
+
+    it('resolves a job payload that omits expectedSeconds', async () => {
+      const job: Job = {
+        uid: 'J9a1b2c3d4e5f6071',
+        group: 'AccountMerge',
+        status: JobStatus.PROCESSING,
+        created: new Date('2026-07-30T09:00:00.000Z'),
+      };
+      const mockHttp = createMockHttpClient(job);
+      const api = new JobApi(mockHttp);
+
+      const result = await api.get(job.uid);
+
+      expect(result).toEqual(job);
+      expect(result.uid).toBe('J9a1b2c3d4e5f6071');
+      expect(result.group).toBe('AccountMerge');
+      expect(result.status).toBe(JobStatus.PROCESSING);
+      expect(result.created).toEqual(new Date('2026-07-30T09:00:00.000Z'));
+      expect(result.expectedSeconds).toBeUndefined();
+      expect(mockHttp.request).toHaveBeenCalledTimes(1);
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'job/J9a1b2c3d4e5f6071', method: 'GET' });
+    });
   });
 });
 

--- a/packages/core/src/client/DfxApiClient.ts
+++ b/packages/core/src/client/DfxApiClient.ts
@@ -6,6 +6,7 @@ import { BankAccountApi } from './BankAccountApi';
 import { BuyApi } from './BuyApi';
 import { CountryApi } from './CountryApi';
 import { FiatApi } from './FiatApi';
+import { JobApi } from './JobApi';
 import { KycApi } from './KycApi';
 import { LanguageApi } from './LanguageApi';
 import { PaymentLinksApi } from './PaymentLinksApi';
@@ -34,6 +35,7 @@ export class DfxApiClient {
   readonly buy: BuyApi;
   readonly country: CountryApi;
   readonly fiat: FiatApi;
+  readonly job: JobApi;
   readonly kyc: KycApi;
   readonly language: LanguageApi;
   readonly paymentLinks: PaymentLinksApi;
@@ -58,6 +60,7 @@ export class DfxApiClient {
     this.buy = new BuyApi(this.http);
     this.country = new CountryApi(this.http);
     this.fiat = new FiatApi(this.http);
+    this.job = new JobApi(this.http);
     this.kyc = new KycApi(this.http);
     this.language = new LanguageApi(this.http);
     this.paymentLinks = new PaymentLinksApi(this.http);

--- a/packages/core/src/client/JobApi.ts
+++ b/packages/core/src/client/JobApi.ts
@@ -1,0 +1,10 @@
+import { Job, JobUrl } from '../definitions/job';
+import { DfxHttpClient } from './DfxHttpClient';
+
+export class JobApi {
+  constructor(private readonly http: DfxHttpClient) {}
+
+  async get<T = unknown>(uid: string): Promise<Job<T>> {
+    return this.http.request<Job<T>>({ url: JobUrl.get(uid), method: 'GET' });
+  }
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -12,6 +12,7 @@ export type { CreateBankAccount, UpdateBankAccount } from './BankAccountApi';
 export { BuyApi } from './BuyApi';
 export { CountryApi } from './CountryApi';
 export { FiatApi } from './FiatApi';
+export { JobApi } from './JobApi';
 export { KycApi } from './KycApi';
 export { LanguageApi } from './LanguageApi';
 export { PaymentLinksApi } from './PaymentLinksApi';

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -32,6 +32,8 @@ export type { Fees } from './fees';
 export { FiatUrl } from './fiat';
 export type { Fiat } from './fiat';
 export type { CustomFile } from './file';
+export { JobUrl, JobStatus, isJobFinished } from './job';
+export type { Job } from './job';
 export { UserRole } from './jwt';
 export type { Jwt } from './jwt';
 export {

--- a/packages/core/src/definitions/job.ts
+++ b/packages/core/src/definitions/job.ts
@@ -17,7 +17,7 @@ export interface Job<T = unknown> {
   created: Date;
   started?: Date;
   finished?: Date;
-  expectedSeconds: number;
+  expectedSeconds?: number;
   result?: T;
   error?: string;
 }

--- a/packages/core/src/definitions/job.ts
+++ b/packages/core/src/definitions/job.ts
@@ -1,0 +1,27 @@
+export const JobUrl = {
+  get: (uid: string) => `job/${uid}`,
+};
+
+export enum JobStatus {
+  PENDING = 'Pending',
+  PROCESSING = 'Processing',
+  COMPLETE = 'Complete',
+  FAILED = 'Failed',
+  DEAD_LETTER = 'DeadLetter',
+}
+
+export interface Job<T = unknown> {
+  uid: string;
+  group: string;
+  status: JobStatus;
+  created: Date;
+  started?: Date;
+  finished?: Date;
+  expectedSeconds: number;
+  result?: T;
+  error?: string;
+}
+
+export function isJobFinished(status: JobStatus): boolean {
+  return [JobStatus.COMPLETE, JobStatus.FAILED, JobStatus.DEAD_LETTER].includes(status);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,10 @@ export {
   ApiException,
   // Fiat
   FiatUrl,
+  // Job
+  JobUrl,
+  JobStatus,
+  isJobFinished,
   // JWT
   UserRole,
   // KYC
@@ -154,6 +158,8 @@ export type {
   Fiat,
   // File
   CustomFile,
+  // Job
+  Job,
   // JWT
   Jwt,
   // KYC

--- a/packages/react/src/contexts/job.context.tsx
+++ b/packages/react/src/contexts/job.context.tsx
@@ -8,8 +8,7 @@ export interface JobStatusMessage {
 }
 
 export interface JobContextInterface {
-  subscribe: (uid: string, onStatus: (message: JobStatusMessage) => void) => void;
-  unsubscribe: (uid: string) => void;
+  subscribe: (uid: string, onStatus: (message: JobStatusMessage) => void) => () => void;
 }
 
 const JobContext = createContext<JobContextInterface>(undefined as any);
@@ -23,9 +22,22 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 30000;
 const RECONNECT_MAX_ATTEMPTS = 5;
 
+function isJobStatusMessage(value: unknown): value is JobStatusMessage {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as { uid?: unknown; status?: unknown };
+  if (typeof candidate.uid !== 'string' || typeof candidate.status !== 'string') {
+    return false;
+  }
+
+  return (Object.values(JobStatus) as string[]).includes(candidate.status);
+}
+
 export function JobContextProvider(props: PropsWithChildren): JSX.Element {
   const { defaultUrl } = useApi();
-  const subscribersRef = useRef(new Map<string, (message: JobStatusMessage) => void>());
+  const subscribersRef = useRef(new Map<string, Set<(message: JobStatusMessage) => void>>());
   const socketRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const reconnectAttemptRef = useRef(0);
@@ -80,18 +92,24 @@ export function JobContextProvider(props: PropsWithChildren): JSX.Element {
     };
 
     socket.onmessage = (event: MessageEvent) => {
-      let message: JobStatusMessage;
+      let parsed: unknown;
       try {
-        message = JSON.parse(String(event.data)) as JobStatusMessage;
+        parsed = JSON.parse(String(event.data));
       } catch {
         // Malformed socket payloads are ignored; they must not crash the app.
         return;
       }
 
-      const onStatus = subscribersRef.current.get(message.uid);
-      if (onStatus) {
-        onStatus(message);
+      if (!isJobStatusMessage(parsed)) {
+        // Non-object or incomplete payloads are discarded the same way as parse failures.
+        return;
       }
+
+      // Copied into a const because the narrowing from the guard above does not survive into the
+      // callback closure. forEach rather than for...of: this package compiles below ES2015, where
+      // iterating a Set would need downlevelIteration.
+      const message = parsed;
+      subscribersRef.current.get(message.uid)?.forEach((onStatus) => onStatus(message));
     };
 
     socket.onclose = () => {
@@ -118,23 +136,32 @@ export function JobContextProvider(props: PropsWithChildren): JSX.Element {
   }, [buildSocketUrl, clearReconnectTimer, closeSocket]);
 
   const subscribe = useCallback(
-    (uid: string, onStatus: (message: JobStatusMessage) => void) => {
-      subscribersRef.current.set(uid, onStatus);
+    (uid: string, onStatus: (message: JobStatusMessage) => void): (() => void) => {
+      let listeners = subscribersRef.current.get(uid);
+      if (listeners === undefined) {
+        listeners = new Set();
+        subscribersRef.current.set(uid, listeners);
+      }
+      listeners.add(onStatus);
       reconnectAttemptRef.current = 0;
       connect();
-    },
-    [connect],
-  );
 
-  const unsubscribe = useCallback(
-    (uid: string) => {
-      subscribersRef.current.delete(uid);
-      if (subscribersRef.current.size === 0) {
-        clearReconnectTimer();
-        closeSocket();
-        return;
-      }
-      connect();
+      return () => {
+        const current = subscribersRef.current.get(uid);
+        if (current === undefined) {
+          return;
+        }
+        current.delete(onStatus);
+        if (current.size === 0) {
+          subscribersRef.current.delete(uid);
+          if (subscribersRef.current.size === 0) {
+            clearReconnectTimer();
+            closeSocket();
+            return;
+          }
+          connect();
+        }
+      };
     },
     [clearReconnectTimer, closeSocket, connect],
   );
@@ -156,9 +183,8 @@ export function JobContextProvider(props: PropsWithChildren): JSX.Element {
   const context = useMemo(
     () => ({
       subscribe,
-      unsubscribe,
     }),
-    [subscribe, unsubscribe],
+    [subscribe],
   );
 
   return <JobContext.Provider value={context}>{props.children}</JobContext.Provider>;

--- a/packages/react/src/contexts/job.context.tsx
+++ b/packages/react/src/contexts/job.context.tsx
@@ -1,0 +1,165 @@
+import { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { JobStatus } from '../definitions/job';
+import { useApi } from '../hooks/api.hook';
+
+export interface JobStatusMessage {
+  uid: string;
+  status: JobStatus;
+}
+
+export interface JobContextInterface {
+  subscribe: (uid: string, onStatus: (message: JobStatusMessage) => void) => void;
+  unsubscribe: (uid: string) => void;
+}
+
+const JobContext = createContext<JobContextInterface>(undefined as any);
+
+export function useJobContext(): JobContextInterface {
+  return useContext(JobContext);
+}
+
+// Reconnect backoff: 1s base, doubles each attempt, max delay 30s, give up after 5 attempts until next subscribe.
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30000;
+const RECONNECT_MAX_ATTEMPTS = 5;
+
+export function JobContextProvider(props: PropsWithChildren): JSX.Element {
+  const { defaultUrl } = useApi();
+  const subscribersRef = useRef(new Map<string, (message: JobStatusMessage) => void>());
+  const socketRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const reconnectAttemptRef = useRef(0);
+  const intentionalCloseRef = useRef(false);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current !== undefined) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = undefined;
+    }
+  }, []);
+
+  const detachSocketHandlers = useCallback((socket: WebSocket) => {
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+  }, []);
+
+  const closeSocket = useCallback(() => {
+    const socket = socketRef.current;
+    if (socket === null) {
+      return;
+    }
+    intentionalCloseRef.current = true;
+    detachSocketHandlers(socket);
+    socket.close();
+    socketRef.current = null;
+  }, [detachSocketHandlers]);
+
+  const buildSocketUrl = useCallback((): string => {
+    const uids = Array.from(subscribersRef.current.keys());
+    const wsBase = defaultUrl.replace(/^http/, 'ws');
+    const query = uids.map((uid) => `uid=${encodeURIComponent(uid)}`).join('&');
+    return `${wsBase}/job?${query}`;
+  }, [defaultUrl]);
+
+  const connect = useCallback(() => {
+    if (subscribersRef.current.size === 0) {
+      return;
+    }
+
+    clearReconnectTimer();
+    closeSocket();
+
+    intentionalCloseRef.current = false;
+    const socket = new WebSocket(buildSocketUrl());
+    socketRef.current = socket;
+
+    socket.onopen = () => {
+      reconnectAttemptRef.current = 0;
+    };
+
+    socket.onmessage = (event: MessageEvent) => {
+      let message: JobStatusMessage;
+      try {
+        message = JSON.parse(String(event.data)) as JobStatusMessage;
+      } catch {
+        // Malformed socket payloads are ignored; they must not crash the app.
+        return;
+      }
+
+      const onStatus = subscribersRef.current.get(message.uid);
+      if (onStatus) {
+        onStatus(message);
+      }
+    };
+
+    socket.onclose = () => {
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+      if (intentionalCloseRef.current || subscribersRef.current.size === 0) {
+        return;
+      }
+      if (reconnectAttemptRef.current >= RECONNECT_MAX_ATTEMPTS) {
+        return;
+      }
+
+      const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, reconnectAttemptRef.current), RECONNECT_MAX_DELAY_MS);
+      reconnectAttemptRef.current += 1;
+      reconnectTimerRef.current = setTimeout(() => {
+        connect();
+      }, delay);
+    };
+
+    socket.onerror = () => {
+      socket.close();
+    };
+  }, [buildSocketUrl, clearReconnectTimer, closeSocket]);
+
+  const subscribe = useCallback(
+    (uid: string, onStatus: (message: JobStatusMessage) => void) => {
+      subscribersRef.current.set(uid, onStatus);
+      reconnectAttemptRef.current = 0;
+      connect();
+    },
+    [connect],
+  );
+
+  const unsubscribe = useCallback(
+    (uid: string) => {
+      subscribersRef.current.delete(uid);
+      if (subscribersRef.current.size === 0) {
+        clearReconnectTimer();
+        closeSocket();
+        return;
+      }
+      connect();
+    },
+    [clearReconnectTimer, closeSocket, connect],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearReconnectTimer();
+      const socket = socketRef.current;
+      if (socket !== null) {
+        intentionalCloseRef.current = true;
+        detachSocketHandlers(socket);
+        socket.close();
+        socketRef.current = null;
+      }
+      subscribersRef.current.clear();
+    };
+  }, [clearReconnectTimer, detachSocketHandlers]);
+
+  const context = useMemo(
+    () => ({
+      subscribe,
+      unsubscribe,
+    }),
+    [subscribe, unsubscribe],
+  );
+
+  return <JobContext.Provider value={context}>{props.children}</JobContext.Provider>;
+}

--- a/packages/react/src/definitions/job.ts
+++ b/packages/react/src/definitions/job.ts
@@ -1,3 +1,2 @@
 export { JobUrl, JobStatus, isJobFinished } from '@dfx.swiss/core';
-
 export type { Job } from '@dfx.swiss/core';

--- a/packages/react/src/definitions/job.ts
+++ b/packages/react/src/definitions/job.ts
@@ -1,0 +1,3 @@
+export { JobUrl, JobStatus, isJobFinished } from '@dfx.swiss/core';
+
+export type { Job } from '@dfx.swiss/core';

--- a/packages/react/src/hooks/job.hook.ts
+++ b/packages/react/src/hooks/job.hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useJobContext } from '../contexts/job.context';
 import { isJobFinished, Job, JobUrl } from '../definitions/job';
 import { useApi } from './api.hook';
@@ -20,33 +20,41 @@ export function useJob(uid: string | undefined): UseJobInterface {
   const [job, setJob] = useState<Job | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(uid !== undefined);
   const [error, setError] = useState<string | undefined>(undefined);
-
-  const activeRef = useRef(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const attemptRef = useRef(0);
-  const subscribedUidRef = useRef<string | undefined>(undefined);
+  const [isOverdue, setIsOverdue] = useState(false);
 
   useEffect(() => {
-    activeRef.current = true;
-    attemptRef.current = 0;
+    // Effect-scoped guard: shared refs would let a stale fetch from a previous uid write after a re-run.
+    let cancelled = false;
+    // Once settled (finished job, timeout, or cleanup), no further setJob/setIsLoading/setError from this run.
+    let settled = false;
+    let fetchInFlight = false;
+    let refetchRequested = false;
+    let attempt = 0;
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let maxTrackingTimer: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribeFromContext: (() => void) | undefined;
 
-    const clearTimer = () => {
-      if (timerRef.current !== undefined) {
-        clearTimeout(timerRef.current);
-        timerRef.current = undefined;
+    const clearPollTimer = () => {
+      if (pollTimer !== undefined) {
+        clearTimeout(pollTimer);
+        pollTimer = undefined;
       }
     };
 
-    const unsubscribeFromContext = () => {
-      if (jobContext && subscribedUidRef.current !== undefined) {
-        jobContext.unsubscribe(subscribedUidRef.current);
-        subscribedUidRef.current = undefined;
+    const clearMaxTrackingTimer = () => {
+      if (maxTrackingTimer !== undefined) {
+        clearTimeout(maxTrackingTimer);
+        maxTrackingTimer = undefined;
       }
     };
 
     const stopTracking = () => {
-      clearTimer();
-      unsubscribeFromContext();
+      clearPollTimer();
+      clearMaxTrackingTimer();
+      if (unsubscribeFromContext !== undefined) {
+        unsubscribeFromContext();
+        unsubscribeFromContext = undefined;
+      }
     };
 
     if (uid === undefined) {
@@ -54,7 +62,8 @@ export function useJob(uid: string | undefined): UseJobInterface {
       setIsLoading(false);
       setError(undefined);
       return () => {
-        activeRef.current = false;
+        cancelled = true;
+        settled = true;
         stopTracking();
       };
     }
@@ -63,52 +72,78 @@ export function useJob(uid: string | undefined): UseJobInterface {
     setIsLoading(true);
     setError(undefined);
 
-    const startTime = Date.now();
+    // Dedicated cap so a hung fetch cannot prevent the 10-minute timeout from firing.
+    maxTrackingTimer = setTimeout(() => {
+      if (cancelled || settled) {
+        return;
+      }
+      settled = true;
+      setError('Job tracking timed out after 10 minutes');
+      setIsLoading(false);
+      stopTracking();
+    }, MAX_TRACKING_MS);
 
-    const fetchJob = async (): Promise<boolean> => {
+    const runFetch = async (): Promise<void> => {
+      if (cancelled || settled) {
+        return;
+      }
+      if (fetchInFlight) {
+        // Coalesce concurrent poll/socket triggers into a single follow-up fetch.
+        refetchRequested = true;
+        return;
+      }
+
+      fetchInFlight = true;
       try {
-        const result = await call<Job>({ url: JobUrl.get(uid), method: 'GET' });
-        if (!activeRef.current) {
-          return true;
+        for (;;) {
+          refetchRequested = false;
+          if (cancelled || settled) {
+            return;
+          }
+          try {
+            const result = await call<Job>({ url: JobUrl.get(uid), method: 'GET' });
+            if (cancelled || settled) {
+              return;
+            }
+            setJob(result);
+            setIsLoading(false);
+            if (isJobFinished(result.status)) {
+              settled = true;
+              stopTracking();
+              return;
+            }
+          } catch {
+            // Transient poll failures are skipped; the next scheduled interval retries.
+          }
+          if (!refetchRequested) {
+            return;
+          }
         }
-        setJob(result);
-        setIsLoading(false);
-        if (isJobFinished(result.status)) {
-          stopTracking();
-          return true;
+      } finally {
+        fetchInFlight = false;
+        if (refetchRequested && !cancelled && !settled) {
+          refetchRequested = false;
+          void runFetch();
         }
-        return false;
-      } catch {
-        // Transient poll failures are skipped; the next scheduled interval retries.
-        return false;
       }
     };
 
     const scheduleNext = () => {
-      if (!activeRef.current) {
+      if (cancelled || settled) {
         return;
       }
 
-      const delay = attemptRef.current < POLL_DELAYS_MS.length ? POLL_DELAYS_MS[attemptRef.current] : STEADY_POLL_MS;
+      const delay = attempt < POLL_DELAYS_MS.length ? POLL_DELAYS_MS[attempt] : STEADY_POLL_MS;
 
-      timerRef.current = setTimeout(() => {
+      pollTimer = setTimeout(() => {
         void (async () => {
-          if (!activeRef.current) {
+          if (cancelled || settled) {
             return;
           }
 
-          if (Date.now() - startTime >= MAX_TRACKING_MS) {
-            if (activeRef.current) {
-              setError('Job tracking timed out after 10 minutes');
-              setIsLoading(false);
-            }
-            stopTracking();
-            return;
-          }
-
-          attemptRef.current += 1;
-          const finished = await fetchJob();
-          if (!activeRef.current || finished) {
+          attempt += 1;
+          await runFetch();
+          if (cancelled || settled) {
             return;
           }
           scheduleNext();
@@ -117,29 +152,49 @@ export function useJob(uid: string | undefined): UseJobInterface {
     };
 
     if (jobContext) {
-      jobContext.subscribe(uid, () => {
-        void fetchJob();
+      unsubscribeFromContext = jobContext.subscribe(uid, () => {
+        void runFetch();
       });
-      subscribedUidRef.current = uid;
     }
 
     scheduleNext();
 
     return () => {
-      activeRef.current = false;
+      cancelled = true;
+      settled = true;
       stopTracking();
     };
   }, [uid, call, jobContext]);
 
-  const isOverdue = useMemo(() => {
+  useEffect(() => {
     if (!job || isJobFinished(job.status)) {
-      return false;
+      setIsOverdue(false);
+      return;
     }
     // expectedSeconds may be absent on the wire; do not invent a default — overdue is false without it.
     if (typeof job.expectedSeconds !== 'number') {
-      return false;
+      setIsOverdue(false);
+      return;
     }
-    return Date.now() - new Date(job.created).getTime() > job.expectedSeconds * 1000;
+
+    // isOverdue depends on the client's local clock relative to the server's created timestamp;
+    // a skewed client clock will report overdue early, late, or never.
+    const deadline = new Date(job.created).getTime() + job.expectedSeconds * 1000;
+    const remainingMs = deadline - Date.now();
+
+    if (remainingMs <= 0) {
+      setIsOverdue(true);
+      return;
+    }
+
+    setIsOverdue(false);
+    const timer = setTimeout(() => {
+      setIsOverdue(true);
+    }, remainingMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
   }, [job]);
 
   return useMemo(

--- a/packages/react/src/hooks/job.hook.ts
+++ b/packages/react/src/hooks/job.hook.ts
@@ -89,8 +89,7 @@ export function useJob(uid: string | undefined): UseJobInterface {
         return;
       }
 
-      const delay =
-        attemptRef.current < POLL_DELAYS_MS.length ? POLL_DELAYS_MS[attemptRef.current] : STEADY_POLL_MS;
+      const delay = attemptRef.current < POLL_DELAYS_MS.length ? POLL_DELAYS_MS[attemptRef.current] : STEADY_POLL_MS;
 
       timerRef.current = setTimeout(() => {
         void (async () => {

--- a/packages/react/src/hooks/job.hook.ts
+++ b/packages/react/src/hooks/job.hook.ts
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useJobContext } from '../contexts/job.context';
+import { isJobFinished, Job, JobUrl } from '../definitions/job';
+import { useApi } from './api.hook';
+
+export interface UseJobInterface {
+  job: Job | undefined;
+  isLoading: boolean;
+  isOverdue: boolean;
+  error: string | undefined;
+}
+
+const POLL_DELAYS_MS = [1000, 2000, 5000];
+const STEADY_POLL_MS = 5000;
+const MAX_TRACKING_MS = 600000;
+
+export function useJob(uid: string | undefined): UseJobInterface {
+  const { call } = useApi();
+  const jobContext = useJobContext();
+  const [job, setJob] = useState<Job | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(uid !== undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const activeRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const attemptRef = useRef(0);
+  const subscribedUidRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    activeRef.current = true;
+    attemptRef.current = 0;
+
+    const clearTimer = () => {
+      if (timerRef.current !== undefined) {
+        clearTimeout(timerRef.current);
+        timerRef.current = undefined;
+      }
+    };
+
+    const unsubscribeFromContext = () => {
+      if (jobContext && subscribedUidRef.current !== undefined) {
+        jobContext.unsubscribe(subscribedUidRef.current);
+        subscribedUidRef.current = undefined;
+      }
+    };
+
+    const stopTracking = () => {
+      clearTimer();
+      unsubscribeFromContext();
+    };
+
+    if (uid === undefined) {
+      setJob(undefined);
+      setIsLoading(false);
+      setError(undefined);
+      return () => {
+        activeRef.current = false;
+        stopTracking();
+      };
+    }
+
+    setJob(undefined);
+    setIsLoading(true);
+    setError(undefined);
+
+    const startTime = Date.now();
+
+    const fetchJob = async (): Promise<boolean> => {
+      try {
+        const result = await call<Job>({ url: JobUrl.get(uid), method: 'GET' });
+        if (!activeRef.current) {
+          return true;
+        }
+        setJob(result);
+        setIsLoading(false);
+        if (isJobFinished(result.status)) {
+          stopTracking();
+          return true;
+        }
+        return false;
+      } catch {
+        // Transient poll failures are skipped; the next scheduled interval retries.
+        return false;
+      }
+    };
+
+    const scheduleNext = () => {
+      if (!activeRef.current) {
+        return;
+      }
+
+      const delay =
+        attemptRef.current < POLL_DELAYS_MS.length ? POLL_DELAYS_MS[attemptRef.current] : STEADY_POLL_MS;
+
+      timerRef.current = setTimeout(() => {
+        void (async () => {
+          if (!activeRef.current) {
+            return;
+          }
+
+          if (Date.now() - startTime >= MAX_TRACKING_MS) {
+            if (activeRef.current) {
+              setError('Job tracking timed out after 10 minutes');
+              setIsLoading(false);
+            }
+            stopTracking();
+            return;
+          }
+
+          attemptRef.current += 1;
+          const finished = await fetchJob();
+          if (!activeRef.current || finished) {
+            return;
+          }
+          scheduleNext();
+        })();
+      }, delay);
+    };
+
+    if (jobContext) {
+      jobContext.subscribe(uid, () => {
+        void fetchJob();
+      });
+      subscribedUidRef.current = uid;
+    }
+
+    scheduleNext();
+
+    return () => {
+      activeRef.current = false;
+      stopTracking();
+    };
+  }, [uid, call, jobContext]);
+
+  const isOverdue = useMemo(() => {
+    if (!job || isJobFinished(job.status)) {
+      return false;
+    }
+    // expectedSeconds may be absent on the wire; do not invent a default — overdue is false without it.
+    if (typeof job.expectedSeconds !== 'number') {
+      return false;
+    }
+    return Date.now() - new Date(job.created).getTime() > job.expectedSeconds * 1000;
+  }, [job]);
+
+  return useMemo(
+    () => ({
+      job,
+      isLoading,
+      isOverdue,
+      error,
+    }),
+    [job, isLoading, isOverdue, error],
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@
 export { DfxContextProvider } from './contexts/dfx.context';
 export { SupportChatContextProvider } from './contexts/support.context';
 export { PaymentRoutesContextProvider } from './contexts/payment-routes.context';
+export { JobContextProvider } from './contexts/job.context';
 
 export { useAssetContext } from './contexts/asset.context';
 export { useFiatContext } from './contexts/fiat.context';
@@ -11,6 +12,7 @@ export { useBankAccountContext } from './contexts/bank-account.context';
 export { useSessionContext } from './contexts/session.context';
 export { useUserContext } from './contexts/user.context';
 export { usePaymentRoutesContext } from './contexts/payment-routes.context';
+export { useJobContext } from './contexts/job.context';
 export { useSupportChatContext } from './contexts/support.context';
 
 // Hooks
@@ -32,6 +34,7 @@ export { useSell } from './hooks/sell.hook';
 export { useUser } from './hooks/user.hook';
 export { useSwap } from './hooks/swap.hook';
 export { useSupportChat } from './hooks/support.hook';
+export { useJob } from './hooks/job.hook';
 
 // Definitions
 export { CheckStatus, AmlReason } from './definitions/aml';
@@ -93,6 +96,8 @@ export { InfoBanner, SettingsUrl } from './definitions/settings';
 export { PriceStep } from './definitions/price-step';
 export { Language, LanguageUrl } from './definitions/language';
 export { Jwt, UserRole } from './definitions/jwt';
+export { JobUrl, JobStatus, isJobFinished } from './definitions/job';
+export type { Job } from './definitions/job';
 export {
   AccountType,
   KycStatus,


### PR DESCRIPTION
## Why

Command endpoints that need more than a moment are moving to a ticket model: the endpoint answers immediately with a ticket, the work runs in the background, and the client follows the ticket to its result. Clients need a way to do that following, and it should exist once rather than in every consumer.

## What

`@dfx.swiss/core`
- `definitions/job.ts` — `JobStatus`, `Job<T>`, `JobUrl`, and `isJobFinished`, so the set of end states is defined in one place instead of being re-listed at every call site.
- `client/JobApi.ts` — `get<T>(uid)` against the status endpoint, registered on `DfxApiClient` as `client.job`.
- A test pinning that a `202 Accepted` with a JSON body arrives at the caller as a success, since that is the response the ticket model relies on.

`@dfx.swiss/react`
- `hooks/job.hook.ts` — `useJob(uid)` returns the job, a loading flag, an `isOverdue` flag and an error.
- `contexts/job.context.tsx` — pools every observed ticket onto a single socket instead of opening one per ticket.

## Design decisions worth reviewing

**Polling carries the tracking, the socket only accelerates it.** A ticket whose socket never connects still reaches its end state. This is deliberate: a push that is treated as the primary path turns every socket problem into a stuck user.

**A transient fetch failure does not end the tracking.** Only the ten-minute cap does. A network blip is not a broken job, and ending the tracking on one would strand a job that is in fact progressing.

**No invented defaults.** If `expectedSeconds` is missing, `isOverdue` stays false rather than falling back to a made-up threshold.

**Reconnects are bounded.** The context backs off and gives up rather than looping forever.

Additive only — no existing public API changes. Per the contributing guide, this touches source only: no version fields, no changelog, no lockfile.

---

## After the first review round

Ten findings, four of them races in the tracking path. All fixed.

A response for the **previous** `uid` could land after a switch and overwrite the new state — and worse, the cleanup could unsubscribe the *new* ticket, because the refs were shared across effect runs instead of scoped to one. Each run now owns its cancelled flag and its own subscribed `uid`.

**Polling and the socket could overtake each other.** Both wrote every response, so a late `Pending` was able to replace an already reached `Complete` and revive the timer. Fetches are single-flight now, with a settled latch that is set before timers and subscription are torn down; nothing is accepted afterwards.

**The ten-minute cap only ran between cycles**, so a hung request kept the tracking alive indefinitely. It is now an independent timer started with the effect.

**The context held one callback per ticket.** Two hooks watching the same `uid` overwrote each other, and the first unsubscribe took the survivor with it. It keeps a set per `uid` and hands back a cleanup that removes only its own.

Smaller ones: `expectedSeconds` is typed optional to match how it is actually handled, socket payloads are validated as objects with a string `uid` before use, `isOverdue` re-evaluates on a deadline timer instead of freezing between responses, and the re-export matches its neighbours.

**One finding was deliberately not acted on.** The date fields are typed `Date` while the wire carries ISO strings — true, but every other definition in this package does exactly the same, without exception. Changing only this file would have made it the single deviation from a package-wide convention. That belongs in its own decision across the package, not in this PR.
