### PR TITLE
feat(core,react): add the personal IBAN client contract

### DIFF
--- a/packages/core/src/__tests__/buy-api.test.ts
+++ b/packages/core/src/__tests__/buy-api.test.ts
@@ -1,0 +1,73 @@
+import { BuyApi } from '../client/BuyApi';
+import { DfxHttpClient } from '../client/DfxHttpClient';
+import { VirtualIban, VirtualIbanStatus } from '../definitions/buy';
+
+function createMockHttpClient(response?: any) {
+  const requestMock = jest.fn().mockResolvedValue(response);
+
+  return {
+    request: requestMock,
+    requestAbsolute: jest.fn(),
+    getBaseUrl: jest.fn().mockReturnValue('https://api.dfx.swiss'),
+    getApiUrl: jest.fn().mockReturnValue('https://api.dfx.swiss/v1'),
+    setToken: jest.fn(),
+    getToken: jest.fn(),
+  } as unknown as DfxHttpClient & { request: jest.Mock };
+}
+
+const virtualIban: VirtualIban = {
+  id: 1,
+  iban: 'LI0808811000000000001',
+  bban: '000000000001',
+  currency: 'EUR',
+  active: true,
+  acceptsPayments: true,
+  status: VirtualIbanStatus.ACTIVE,
+};
+
+describe('BuyApi', () => {
+  describe('getPersonalIbans', () => {
+    it('requests the personal IBAN list of the authenticated account', async () => {
+      const mockHttp = createMockHttpClient([virtualIban]);
+      const api = new BuyApi(mockHttp);
+
+      const result = await api.getPersonalIbans();
+
+      expect(result).toEqual([virtualIban]);
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'buy/personalIban', method: 'GET' });
+    });
+
+    it('does not opt out of the auth token', async () => {
+      const mockHttp = createMockHttpClient([]);
+      const api = new BuyApi(mockHttp);
+
+      await api.getPersonalIbans();
+
+      expect(mockHttp.request.mock.calls[0][0]).not.toHaveProperty('token');
+    });
+  });
+
+  describe('createPersonalIban', () => {
+    it('posts the requested currency to the personal IBAN endpoint', async () => {
+      const mockHttp = createMockHttpClient(virtualIban);
+      const api = new BuyApi(mockHttp);
+
+      const result = await api.createPersonalIban({ currency: 'EUR' });
+
+      expect(result).toEqual(virtualIban);
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'buy/personalIban',
+        method: 'POST',
+        data: { currency: 'EUR' },
+      });
+    });
+
+    it('propagates API rejections instead of resolving', async () => {
+      const mockHttp = createMockHttpClient();
+      (mockHttp.request as jest.Mock).mockRejectedValue(new Error('KYC level 50 or higher required'));
+      const api = new BuyApi(mockHttp);
+
+      await expect(api.createPersonalIban({ currency: 'EUR' })).rejects.toThrow('KYC level 50 or higher required');
+    });
+  });
+});

--- a/packages/core/src/__tests__/personal-iban.test.ts
+++ b/packages/core/src/__tests__/personal-iban.test.ts
@@ -1,0 +1,57 @@
+import {
+  PersonalIbanProvider,
+  isUnrecognizedPersonalIbanSelector,
+  normalizePersonalIban,
+  toPersonalIbanProvider,
+  toPersonalIbanProviderRequest,
+} from '../definitions/buy';
+
+describe('personal IBAN selectors', () => {
+  describe('normalizePersonalIban', () => {
+    it.each(['Frick', 'frick', 'FRICK', 'FrIcK'])('maps %s to the canonical provider spelling', (value) => {
+      expect(normalizePersonalIban(value)).toBe(PersonalIbanProvider.FRICK);
+    });
+
+    it('returns undefined for an unset selector', () => {
+      expect(normalizePersonalIban(undefined)).toBeUndefined();
+    });
+
+    it.each(['frik', 'other-bank', ''])('leaves the unknown selector %s unchanged', (value) => {
+      expect(normalizePersonalIban(value)).toBe(value);
+    });
+  });
+
+  describe('toPersonalIbanProvider', () => {
+    it('resolves a known selector to the provider', () => {
+      expect(toPersonalIbanProvider('frick')).toBe(PersonalIbanProvider.FRICK);
+    });
+
+    it.each([undefined, 'frik', ''])('returns undefined for %s', (value) => {
+      expect(toPersonalIbanProvider(value)).toBeUndefined();
+    });
+  });
+
+  describe('isUnrecognizedPersonalIbanSelector', () => {
+    it('is false when no selector was set', () => {
+      expect(isUnrecognizedPersonalIbanSelector(undefined)).toBe(false);
+    });
+
+    it('is false for a known provider', () => {
+      expect(isUnrecognizedPersonalIbanSelector('FRICK')).toBe(false);
+    });
+
+    it.each(['frik', 'other-bank', ''])('is true for the unknown selector %s', (value) => {
+      expect(isUnrecognizedPersonalIbanSelector(value)).toBe(true);
+    });
+  });
+
+  describe('toPersonalIbanProviderRequest', () => {
+    it('carries the canonical provider for a known selector', () => {
+      expect(toPersonalIbanProviderRequest('frick')).toEqual({ personalIbanProvider: PersonalIbanProvider.FRICK });
+    });
+
+    it.each([undefined, 'frik'])('omits the provider for %s', (value) => {
+      expect(toPersonalIbanProviderRequest(value)).toEqual({});
+    });
+  });
+});

--- a/packages/core/src/client/BuyApi.ts
+++ b/packages/core/src/client/BuyApi.ts
@@ -1,4 +1,4 @@
-import { Buy, BuyUrl, BuyPaymentInfo, PdfDocument } from '../definitions/buy';
+import { Buy, BuyUrl, BuyPaymentInfo, CreateVirtualIban, PdfDocument, VirtualIban } from '../definitions/buy';
 import { DfxHttpClient } from './DfxHttpClient';
 
 export class BuyApi {
@@ -18,5 +18,20 @@ export class BuyApi {
 
   async confirm(txId: number): Promise<void> {
     return this.http.request<void>({ url: BuyUrl.confirm(txId), method: 'PUT' });
+  }
+
+  /** Personal IBANs of the authenticated account, across all currencies. */
+  async getPersonalIbans(): Promise<VirtualIban[]> {
+    return this.http.request<VirtualIban[]>({ url: BuyUrl.personalIban, method: 'GET' });
+  }
+
+  /**
+   * Issues a personal IBAN for the authenticated account.
+   *
+   * The API requires a KYC level of at least 50 and rejects unsupported currencies; both arrive as an
+   * ApiException, never as a VirtualIban.
+   */
+  async createPersonalIban(data: CreateVirtualIban): Promise<VirtualIban> {
+    return this.http.request<VirtualIban>({ url: BuyUrl.personalIban, method: 'POST', data });
   }
 }

--- a/packages/core/src/client/BuyApi.ts
+++ b/packages/core/src/client/BuyApi.ts
@@ -28,8 +28,8 @@ export class BuyApi {
   /**
    * Issues a personal IBAN for the authenticated account.
    *
-   * The API requires a KYC level of at least 50 and rejects unsupported currencies; both arrive as an
-   * ApiException, never as a VirtualIban.
+   * Rejections - an insufficient KYC level, an unsupported currency - arrive as an ApiException,
+   * never as a VirtualIban.
    */
   async createPersonalIban(data: CreateVirtualIban): Promise<VirtualIban> {
     return this.http.request<VirtualIban>({ url: BuyUrl.personalIban, method: 'POST', data });

--- a/packages/core/src/definitions/buy.ts
+++ b/packages/core/src/definitions/buy.ts
@@ -9,10 +9,71 @@ export const BuyUrl = {
   receive: 'buy/paymentInfos',
   invoice: (txId: number) => `buy/paymentInfos/${txId}/invoice`,
   confirm: (txId: number) => `buy/paymentInfos/${txId}/confirm`,
+  personalIban: 'buy/personalIban',
 };
 
 export enum PersonalIbanProvider {
   FRICK = 'Frick',
+}
+
+export enum VirtualIbanStatus {
+  RESERVED = 'Reserved',
+  ACTIVE = 'Active',
+  EXPIRED = 'Expired',
+  DEACTIVATED = 'Deactivated',
+}
+
+export interface VirtualIban {
+  id: number;
+  iban: string;
+  bban?: string;
+  currency: string;
+  active: boolean;
+  /** Whether the bank behind this IBAN currently accepts payments. Independent of `active`. */
+  acceptsPayments: boolean;
+  status?: VirtualIbanStatus;
+  label?: string;
+  activatedAt?: Date;
+}
+
+export interface CreateVirtualIban {
+  /** Currency name, e.g. "EUR". */
+  currency: string;
+}
+
+/**
+ * Returns the canonical spelling of a personal IBAN provider selector, matched case-insensitively.
+ * Values that match no known provider are returned unchanged.
+ */
+export function normalizePersonalIban(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+
+  return Object.values(PersonalIbanProvider).find((p) => p.toLowerCase() === value.toLowerCase()) ?? value;
+}
+
+/** Returns the provider for a selector, or undefined when it matches no known provider. */
+export function toPersonalIbanProvider(value: string | undefined): PersonalIbanProvider | undefined {
+  if (value === undefined) return undefined;
+
+  return Object.values(PersonalIbanProvider).find((p) => p.toLowerCase() === value.toLowerCase());
+}
+
+/**
+ * True when a selector was set but matches no known provider (e.g. a typo, or a provider this
+ * version does not know). The API rejects unknown providers, so fail closed on such a selector
+ * instead of dropping it and silently requesting an ordinary bank transfer.
+ */
+export function isUnrecognizedPersonalIbanSelector(value: string | undefined): boolean {
+  return value !== undefined && toPersonalIbanProvider(value) === undefined;
+}
+
+/** Builds the personal IBAN part of a buy payment info request; empty for an unset or unknown selector. */
+export function toPersonalIbanProviderRequest(value: string | undefined): {
+  personalIbanProvider?: PersonalIbanProvider;
+} {
+  const provider = toPersonalIbanProvider(value);
+
+  return provider ? { personalIbanProvider: provider } : {};
 }
 
 export interface Buy {

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -22,8 +22,16 @@ export type { Bank, ReceiveIbanCheck } from './bank';
 export { BankAccountUrl } from './bank-account';
 export type { BankAccount } from './bank-account';
 export { Blockchain } from './blockchain';
-export { BuyUrl, PersonalIbanProvider } from './buy';
-export type { Buy, BuyPaymentInfo, PdfDocument } from './buy';
+export {
+  BuyUrl,
+  PersonalIbanProvider,
+  VirtualIbanStatus,
+  normalizePersonalIban,
+  toPersonalIbanProvider,
+  isUnrecognizedPersonalIbanSelector,
+  toPersonalIbanProviderRequest,
+} from './buy';
+export type { Buy, BuyPaymentInfo, CreateVirtualIban, PdfDocument, VirtualIban } from './buy';
 export { CountryUrl } from './country';
 export type { Country } from './country';
 export { ApiException } from './error';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,11 @@ export {
   // Buy
   BuyUrl,
   PersonalIbanProvider,
+  VirtualIbanStatus,
+  normalizePersonalIban,
+  toPersonalIbanProvider,
+  isUnrecognizedPersonalIbanSelector,
+  toPersonalIbanProviderRequest,
   // Country
   CountryUrl,
   // Error
@@ -143,7 +148,9 @@ export type {
   // Buy
   Buy,
   BuyPaymentInfo,
+  CreateVirtualIban,
   PdfDocument,
+  VirtualIban,
   // Country
   Country,
   // Error

--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -1,7 +1,7 @@
 export { BuyUrl } from '@dfx.swiss/core';
 /** Personal IBAN provider values accepted by buy payment-info requests. */
+export { PersonalIbanProvider } from '@dfx.swiss/core';
 export {
-  PersonalIbanProvider,
   VirtualIbanStatus,
   normalizePersonalIban,
   toPersonalIbanProvider,

--- a/packages/react/src/definitions/buy.ts
+++ b/packages/react/src/definitions/buy.ts
@@ -1,4 +1,11 @@
 export { BuyUrl } from '@dfx.swiss/core';
 /** Personal IBAN provider values accepted by buy payment-info requests. */
-export { PersonalIbanProvider } from '@dfx.swiss/core';
-export type { Buy, BuyPaymentInfo, PdfDocument } from '@dfx.swiss/core';
+export {
+  PersonalIbanProvider,
+  VirtualIbanStatus,
+  normalizePersonalIban,
+  toPersonalIbanProvider,
+  isUnrecognizedPersonalIbanSelector,
+  toPersonalIbanProviderRequest,
+} from '@dfx.swiss/core';
+export type { Buy, BuyPaymentInfo, CreateVirtualIban, PdfDocument, VirtualIban } from '@dfx.swiss/core';

--- a/packages/react/src/hooks/virtual-iban.hook.ts
+++ b/packages/react/src/hooks/virtual-iban.hook.ts
@@ -8,8 +8,8 @@ export interface VirtualIbanInterface {
   /**
    * Issues a personal IBAN for the authenticated account.
    *
-   * The API requires a KYC level of at least 50 and rejects unsupported currencies; both arrive as an
-   * ApiException, never as a VirtualIban.
+   * Rejections - an insufficient KYC level, an unsupported currency - arrive as an ApiException,
+   * never as a VirtualIban.
    */
   createPersonalIban: (data: CreateVirtualIban) => Promise<VirtualIban>;
 }

--- a/packages/react/src/hooks/virtual-iban.hook.ts
+++ b/packages/react/src/hooks/virtual-iban.hook.ts
@@ -1,0 +1,32 @@
+import { useCallback, useMemo } from 'react';
+import { BuyUrl, CreateVirtualIban, VirtualIban } from '../definitions/buy';
+import { useApi } from './api.hook';
+
+export interface VirtualIbanInterface {
+  /** Personal IBANs of the authenticated account, across all currencies. */
+  getPersonalIbans: () => Promise<VirtualIban[]>;
+  /**
+   * Issues a personal IBAN for the authenticated account.
+   *
+   * The API requires a KYC level of at least 50 and rejects unsupported currencies; both arrive as an
+   * ApiException, never as a VirtualIban.
+   */
+  createPersonalIban: (data: CreateVirtualIban) => Promise<VirtualIban>;
+}
+
+export function useVirtualIban(): VirtualIbanInterface {
+  const { call } = useApi();
+
+  const getPersonalIbans = useCallback(async (): Promise<VirtualIban[]> => {
+    return call<VirtualIban[]>({ url: BuyUrl.personalIban, method: 'GET' });
+  }, [call]);
+
+  const createPersonalIban = useCallback(
+    async (data: CreateVirtualIban): Promise<VirtualIban> => {
+      return call<VirtualIban>({ url: BuyUrl.personalIban, method: 'POST', data });
+    },
+    [call],
+  );
+
+  return useMemo(() => ({ getPersonalIbans, createPersonalIban }), [getPersonalIbans, createPersonalIban]);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,7 +30,7 @@ export { useLanguage } from './hooks/language.hook';
 export { useKyc } from './hooks/kyc.hook';
 export { useSell } from './hooks/sell.hook';
 export { useUser } from './hooks/user.hook';
-export { useVirtualIban, VirtualIbanInterface } from './hooks/virtual-iban.hook';
+export { useVirtualIban } from './hooks/virtual-iban.hook';
 export { useSwap } from './hooks/swap.hook';
 export { useSupportChat } from './hooks/support.hook';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export { useLanguage } from './hooks/language.hook';
 export { useKyc } from './hooks/kyc.hook';
 export { useSell } from './hooks/sell.hook';
 export { useUser } from './hooks/user.hook';
+export { useVirtualIban, VirtualIbanInterface } from './hooks/virtual-iban.hook';
 export { useSwap } from './hooks/swap.hook';
 export { useSupportChat } from './hooks/support.hook';
 
@@ -54,6 +55,15 @@ export { Blockchain } from './definitions/blockchain';
 export { Buy, BuyPaymentInfo, PdfDocument, BuyUrl } from './definitions/buy';
 /** Personal IBAN provider values accepted by buy payment-info requests. */
 export { PersonalIbanProvider } from './definitions/buy';
+export {
+  CreateVirtualIban,
+  VirtualIban,
+  VirtualIbanStatus,
+  normalizePersonalIban,
+  toPersonalIbanProvider,
+  isUnrecognizedPersonalIbanSelector,
+  toPersonalIbanProviderRequest,
+} from './definitions/buy';
 export { Country, CountryUrl } from './definitions/country';
 export { ApiError, ApiException } from './definitions/error';
 export { Fiat, FiatUrl } from './definitions/fiat';


### PR DESCRIPTION
Step 1 of #198: move the personal IBAN wire contract into the packages so consumers no longer
need a local `useApi()` wrapper for it.

## Changes

`@dfx.swiss/core`

- `BuyUrl.personalIban` (`buy/personalIban`)
- `VirtualIban`, `CreateVirtualIban`, `VirtualIbanStatus`
- `BuyApi.getPersonalIbans()` and `BuyApi.createPersonalIban()`
- Selector helpers on top of the existing `PersonalIbanProvider` enum: `normalizePersonalIban`,
  `toPersonalIbanProvider`, `isUnrecognizedPersonalIbanSelector`, `toPersonalIbanProviderRequest`

`@dfx.swiss/react`

- `useVirtualIban()` with `getPersonalIbans` / `createPersonalIban`
- Re-exports of the new types and helpers

Tests cover both client methods and every selector helper (`buy-api.test.ts`,
`personal-iban.test.ts`).

## Notes

- **Both endpoints are covered, not just create.** The API exposes `GET buy/personalIban` next to
  `POST buy/personalIban`; the list endpoint is part of the same customer contract, so freezing only
  the create half would leave consumers writing a local wrapper anyway.
- **`acceptsPayments` is part of the response.** The API returns it (whether the bank behind the IBAN
  currently accepts payments, independent of `active`). Consumers that modelled this response locally
  without that field silently dropped it.
- **The selector helpers are provider-generic.** They match case-insensitively against the
  `PersonalIbanProvider` enum instead of comparing to a single hard-coded member, so a future provider
  needs no change at the call sites. Behaviour is identical for today's enum.
- **Deliberately not moved:** user-facing error copy for personal IBAN failures, the
  currency/payment-method applicability rule, and the response check against a specific bank and
  account-holder name. Those encode product state that can change without a contract change, and a
  published SDK that asserts them would start lying the day the API changes. URL and widget parameter
  handling stays with the consumer as well, per the issue.

Additive only — no existing export changes shape, so there is nothing for downstream consumers to
migrate.

Version fields, changelogs and lockfile pins are untouched, per CONTRIBUTING.
