### PR TITLE
feat(core,react): add the customer recommendation client

### DIFF
--- a/packages/core/src/__tests__/recommendation-api.test.ts
+++ b/packages/core/src/__tests__/recommendation-api.test.ts
@@ -1,0 +1,102 @@
+import { DfxHttpClient } from '../client/DfxHttpClient';
+import { RecommendationApi } from '../client/RecommendationApi';
+import {
+  Recommendation,
+  RecommendationMethod,
+  RecommendationStatus,
+  RecommendationType,
+} from '../definitions/recommendation';
+
+function createMockHttpClient(response?: any) {
+  const requestMock = jest.fn().mockResolvedValue(response);
+
+  return {
+    request: requestMock,
+    requestAbsolute: jest.fn(),
+    getBaseUrl: jest.fn().mockReturnValue('https://api.dfx.swiss'),
+    getApiUrl: jest.fn().mockReturnValue('https://api.dfx.swiss/v1'),
+    setToken: jest.fn(),
+    getToken: jest.fn(),
+  } as unknown as DfxHttpClient & { request: jest.Mock };
+}
+
+const recommendation: Recommendation = {
+  id: 42,
+  code: 'ABC123',
+  status: RecommendationStatus.CREATED,
+  type: RecommendationType.INVITATION,
+  method: RecommendationMethod.MAIL,
+  name: 'Alias',
+};
+
+describe('RecommendationApi', () => {
+  describe('list', () => {
+    it('requests the recommendations of the authenticated account', async () => {
+      const mockHttp = createMockHttpClient([recommendation]);
+      const api = new RecommendationApi(mockHttp);
+
+      const result = await api.list();
+
+      expect(result).toEqual([recommendation]);
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'recommendation', method: 'GET' });
+    });
+
+    it('does not opt out of the auth token', async () => {
+      const mockHttp = createMockHttpClient([]);
+      const api = new RecommendationApi(mockHttp);
+
+      await api.list();
+
+      expect(mockHttp.request.mock.calls[0][0]).not.toHaveProperty('token');
+    });
+  });
+
+  describe('create', () => {
+    it('posts alias and mail to the recommendation endpoint', async () => {
+      const mockHttp = createMockHttpClient(recommendation);
+      const api = new RecommendationApi(mockHttp);
+
+      const result = await api.create({ recommendedAlias: 'Alias', recommendedMail: 'someone@example.com' });
+
+      expect(result).toEqual(recommendation);
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'recommendation',
+        method: 'POST',
+        data: { recommendedAlias: 'Alias', recommendedMail: 'someone@example.com' },
+      });
+    });
+
+    it('sends the alias alone when no mail is given', async () => {
+      const mockHttp = createMockHttpClient(recommendation);
+      const api = new RecommendationApi(mockHttp);
+
+      await api.create({ recommendedAlias: 'Alias' });
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'recommendation',
+        method: 'POST',
+        data: { recommendedAlias: 'Alias' },
+      });
+    });
+  });
+
+  describe('confirm and reject', () => {
+    it('confirms by id', async () => {
+      const mockHttp = createMockHttpClient(undefined);
+      const api = new RecommendationApi(mockHttp);
+
+      await api.confirm(42);
+
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'recommendation/42/confirm', method: 'PUT' });
+    });
+
+    it('rejects by id', async () => {
+      const mockHttp = createMockHttpClient(undefined);
+      const api = new RecommendationApi(mockHttp);
+
+      await api.reject(42);
+
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'recommendation/42/reject', method: 'PUT' });
+    });
+  });
+});

--- a/packages/core/src/client/DfxApiClient.ts
+++ b/packages/core/src/client/DfxApiClient.ts
@@ -10,6 +10,7 @@ import { KycApi } from './KycApi';
 import { LanguageApi } from './LanguageApi';
 import { PaymentLinksApi } from './PaymentLinksApi';
 import { PaymentRoutesApi } from './PaymentRoutesApi';
+import { RecommendationApi } from './RecommendationApi';
 import { SellApi } from './SellApi';
 import { SettingsApi } from './SettingsApi';
 import { SupportApi } from './SupportApi';
@@ -38,6 +39,7 @@ export class DfxApiClient {
   readonly language: LanguageApi;
   readonly paymentLinks: PaymentLinksApi;
   readonly paymentRoutes: PaymentRoutesApi;
+  readonly recommendation: RecommendationApi;
   readonly sell: SellApi;
   readonly settings: SettingsApi;
   readonly support: SupportApi;
@@ -62,6 +64,7 @@ export class DfxApiClient {
     this.language = new LanguageApi(this.http);
     this.paymentLinks = new PaymentLinksApi(this.http);
     this.paymentRoutes = new PaymentRoutesApi(this.http);
+    this.recommendation = new RecommendationApi(this.http);
     this.sell = new SellApi(this.http);
     this.settings = new SettingsApi(this.http);
     this.support = new SupportApi(this.http);

--- a/packages/core/src/client/RecommendationApi.ts
+++ b/packages/core/src/client/RecommendationApi.ts
@@ -1,0 +1,29 @@
+import { CreateRecommendation, Recommendation, RecommendationUrl } from '../definitions/recommendation';
+import { DfxHttpClient } from './DfxHttpClient';
+
+export class RecommendationApi {
+  constructor(private readonly http: DfxHttpClient) {}
+
+  /** Recommendations of the authenticated account, both the ones it sent and the ones it received. */
+  async list(): Promise<Recommendation[]> {
+    return this.http.request<Recommendation[]>({ url: RecommendationUrl.recommendation, method: 'GET' });
+  }
+
+  async create(data: CreateRecommendation): Promise<Recommendation> {
+    return this.http.request<Recommendation>({
+      url: RecommendationUrl.recommendation,
+      method: 'POST',
+      data,
+    });
+  }
+
+  /** Accepts a recommendation. The response body is empty; re-read the list for the new status. */
+  async confirm(id: number): Promise<void> {
+    return this.http.request<void>({ url: RecommendationUrl.confirm(id), method: 'PUT' });
+  }
+
+  /** Declines a recommendation. The response body is empty; re-read the list for the new status. */
+  async reject(id: number): Promise<void> {
+    return this.http.request<void>({ url: RecommendationUrl.reject(id), method: 'PUT' });
+  }
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -16,6 +16,7 @@ export { KycApi } from './KycApi';
 export { LanguageApi } from './LanguageApi';
 export { PaymentLinksApi } from './PaymentLinksApi';
 export { PaymentRoutesApi } from './PaymentRoutesApi';
+export { RecommendationApi } from './RecommendationApi';
 export { SellApi } from './SellApi';
 export { SettingsApi } from './SettingsApi';
 export { SupportApi } from './SupportApi';

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -104,6 +104,8 @@ export type {
 export { LanguageUrl } from './language';
 export type { Language } from './language';
 export type { PriceStep } from './price-step';
+export { RecommendationUrl, RecommendationStatus, RecommendationType, RecommendationMethod } from './recommendation';
+export type { Recommendation, CreateRecommendation } from './recommendation';
 export {
   PaymentRoutesUrl,
   PaymentLinksUrl,

--- a/packages/core/src/definitions/recommendation.ts
+++ b/packages/core/src/definitions/recommendation.ts
@@ -1,0 +1,43 @@
+export const RecommendationUrl = {
+  recommendation: 'recommendation',
+  confirm: (id: number) => `recommendation/${id}/confirm`,
+  reject: (id: number) => `recommendation/${id}/reject`,
+};
+
+export enum RecommendationStatus {
+  CREATED = 'Created',
+  PENDING = 'Pending',
+  EXPIRED = 'Expired',
+  REJECTED = 'Rejected',
+  COMPLETED = 'Completed',
+}
+
+export enum RecommendationType {
+  INVITATION = 'Invitation',
+  REQUEST = 'Request',
+}
+
+export enum RecommendationMethod {
+  REF_CODE = 'RefCode',
+  MAIL = 'Mail',
+  RECOMMENDATION_CODE = 'RecommendationCode',
+}
+
+export interface Recommendation {
+  id: number;
+  /** Absent once the code has been used. */
+  code?: string;
+  status: RecommendationStatus;
+  type: RecommendationType;
+  method: RecommendationMethod;
+  name?: string;
+  mail?: string;
+  confirmationDate?: Date;
+  /** Absent for mail invitations, which do not expire. */
+  expirationDate?: Date;
+}
+
+export interface CreateRecommendation {
+  recommendedMail?: string;
+  recommendedAlias: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,11 @@ export {
   isStepDone,
   // Language
   LanguageUrl,
+  // Recommendation
+  RecommendationUrl,
+  RecommendationStatus,
+  RecommendationType,
+  RecommendationMethod,
   // Route
   PaymentRoutesUrl,
   PaymentLinksUrl,
@@ -196,6 +201,9 @@ export type {
   Language,
   // Price Step
   PriceStep,
+  // Recommendation
+  Recommendation,
+  CreateRecommendation,
   // Route
   MinAmount,
   DepositDto,

--- a/packages/react/src/definitions/recommendation.ts
+++ b/packages/react/src/definitions/recommendation.ts
@@ -1,0 +1,2 @@
+export { RecommendationUrl, RecommendationStatus, RecommendationType, RecommendationMethod } from '@dfx.swiss/core';
+export type { Recommendation, CreateRecommendation } from '@dfx.swiss/core';

--- a/packages/react/src/hooks/recommendation.hook.ts
+++ b/packages/react/src/hooks/recommendation.hook.ts
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from 'react';
+import { CreateRecommendation, Recommendation, RecommendationUrl } from '../definitions/recommendation';
+import { useApi } from './api.hook';
+
+export interface RecommendationInterface {
+  /** Recommendations of the authenticated account, both the ones it sent and the ones it received. */
+  getRecommendations: () => Promise<Recommendation[]>;
+  createRecommendation: (data: CreateRecommendation) => Promise<Recommendation>;
+  /** Accepts a recommendation. The response body is empty; re-read the list for the new status. */
+  confirmRecommendation: (id: number) => Promise<void>;
+  /** Declines a recommendation. The response body is empty; re-read the list for the new status. */
+  rejectRecommendation: (id: number) => Promise<void>;
+}
+
+export function useRecommendation(): RecommendationInterface {
+  const { call } = useApi();
+
+  const getRecommendations = useCallback(async (): Promise<Recommendation[]> => {
+    return call<Recommendation[]>({ url: RecommendationUrl.recommendation, method: 'GET' });
+  }, [call]);
+
+  const createRecommendation = useCallback(
+    async (data: CreateRecommendation): Promise<Recommendation> => {
+      return call<Recommendation>({ url: RecommendationUrl.recommendation, method: 'POST', data });
+    },
+    [call],
+  );
+
+  const confirmRecommendation = useCallback(
+    async (id: number): Promise<void> => {
+      return call<void>({ url: RecommendationUrl.confirm(id), method: 'PUT' });
+    },
+    [call],
+  );
+
+  const rejectRecommendation = useCallback(
+    async (id: number): Promise<void> => {
+      return call<void>({ url: RecommendationUrl.reject(id), method: 'PUT' });
+    },
+    [call],
+  );
+
+  return useMemo(
+    () => ({ getRecommendations, createRecommendation, confirmRecommendation, rejectRecommendation }),
+    [getRecommendations, createRecommendation, confirmRecommendation, rejectRecommendation],
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,7 +24,7 @@ export { useBuy } from './hooks/buy.hook';
 export { useCountry } from './hooks/country.hook';
 export { useFiat } from './hooks/fiat.hook';
 export { usePaymentRoutes } from './hooks/payment-routes.hook';
-export { useRecommendation, RecommendationInterface } from './hooks/recommendation.hook';
+export { useRecommendation } from './hooks/recommendation.hook';
 export { useSettings } from './hooks/settings.hook';
 export { useTransaction } from './hooks/transaction.hook';
 export { useLanguage } from './hooks/language.hook';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ export { useBuy } from './hooks/buy.hook';
 export { useCountry } from './hooks/country.hook';
 export { useFiat } from './hooks/fiat.hook';
 export { usePaymentRoutes } from './hooks/payment-routes.hook';
+export { useRecommendation, RecommendationInterface } from './hooks/recommendation.hook';
 export { useSettings } from './hooks/settings.hook';
 export { useTransaction } from './hooks/transaction.hook';
 export { useLanguage } from './hooks/language.hook';
@@ -89,6 +90,14 @@ export {
   PaymentRoutesUrl,
   PaymentLinksUrl,
 } from './definitions/route';
+export {
+  Recommendation,
+  CreateRecommendation,
+  RecommendationUrl,
+  RecommendationStatus,
+  RecommendationType,
+  RecommendationMethod,
+} from './definitions/recommendation';
 export { InfoBanner, SettingsUrl } from './definitions/settings';
 export { PriceStep } from './definitions/price-step';
 export { Language, LanguageUrl } from './definitions/language';


### PR DESCRIPTION
Step 2 of #198: move the customer-facing recommendation contract into the packages.

## Changes

`@dfx.swiss/core`

- `RecommendationUrl` (`recommendation`, `recommendation/:id/confirm`, `recommendation/:id/reject`)
- `Recommendation`, `CreateRecommendation`, `RecommendationStatus`, `RecommendationType`,
  `RecommendationMethod`
- `RecommendationApi` with `list`, `create`, `confirm`, `reject`, wired into `DfxApiClient` as
  `client.recommendation`

`@dfx.swiss/react`

- `useRecommendation()` with `getRecommendations`, `createRecommendation`, `confirmRecommendation`,
  `rejectRecommendation`
- Re-exports of the new types

Tests cover all four client methods (`recommendation-api.test.ts`).

## Notes

- **`expirationDate` is optional.** The API omits it for mail invitations (those do not expire), so
  modelling it as always present is wrong — a consumer that formats it unconditionally renders an
  invalid date for exactly that case. `code` is likewise absent once the code has been used.
- **`confirm` and `reject` take an id, not the whole recommendation.** Nothing but the id reaches the
  wire, and requiring a full object would force callers to keep one around just to decline.
- **Both calls return an empty body.** They resolve to `void`; re-read the list to observe the new
  status.
- **Staff scope stays out.** Only the account-scoped customer endpoints are covered here; the staff
  recommendation graph is not part of this contract.

Additive only — no existing export changes shape.

Version fields, changelogs and lockfile pins are untouched, per CONTRIBUTING.
