### PR TITLE
feat(core,react): add the payment link pay flow contract

### DIFF
--- a/packages/core/src/__tests__/payment-links-api.test.ts
+++ b/packages/core/src/__tests__/payment-links-api.test.ts
@@ -146,7 +146,12 @@ describe('hasPaymentQuote', () => {
   });
 
   it('is false for an idle terminal response', () => {
-    const response: PaymentLinkPayResponse = { ...requestBase, error: 'No pending payment', statusCode: 404 };
+    const response: PaymentLinkPayResponse = {
+      ...requestBase,
+      error: 'Not Found',
+      message: 'No pending payment',
+      statusCode: 404,
+    };
 
     expect(hasPaymentQuote(response)).toBe(false);
   });

--- a/packages/core/src/__tests__/payment-links-api.test.ts
+++ b/packages/core/src/__tests__/payment-links-api.test.ts
@@ -1,0 +1,153 @@
+import { DfxHttpClient } from '../client/DfxHttpClient';
+import { PaymentLinksApi } from '../client/PaymentLinksApi';
+import {
+  PaymentLinkMode,
+  PaymentLinkPayResponse,
+  PaymentLinkPaymentStatus,
+  PaymentStandardType,
+  hasPaymentQuote,
+} from '../definitions/route';
+
+function createMockHttpClient(response?: any) {
+  const requestMock = jest.fn().mockResolvedValue(response);
+
+  return {
+    request: requestMock,
+    requestAbsolute: jest.fn(),
+    getBaseUrl: jest.fn().mockReturnValue('https://api.dfx.swiss'),
+    getApiUrl: jest.fn().mockReturnValue('https://api.dfx.swiss/v1'),
+    setToken: jest.fn(),
+    getToken: jest.fn(),
+  } as unknown as DfxHttpClient & { request: jest.Mock };
+}
+
+const requestBase = {
+  id: 'pl_1',
+  displayName: 'Shop',
+  standard: PaymentStandardType.OPEN_CRYPTO_PAY,
+  possibleStandards: [PaymentStandardType.OPEN_CRYPTO_PAY],
+  displayQr: true,
+  recipient: { name: 'Shop' },
+  mode: PaymentLinkMode.SINGLE,
+  transferAmounts: [],
+};
+
+describe('PaymentLinksApi pay flow', () => {
+  describe('getStandards', () => {
+    it('reads the public standard list without a token', async () => {
+      const mockHttp = createMockHttpClient([]);
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.getStandards();
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/standard',
+        method: 'GET',
+        token: false,
+      });
+    });
+
+    it('reads a single standard by id', async () => {
+      const mockHttp = createMockHttpClient({});
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.getStandard(PaymentStandardType.PAY_TO_ADDRESS);
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/standard/PayToAddress',
+        method: 'GET',
+        token: false,
+      });
+    });
+  });
+
+  describe('waitForPayment', () => {
+    it('passes the link identification as query parameters', async () => {
+      const mockHttp = createMockHttpClient({});
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.waitForPayment({ externalLinkId: 'ext 1', key: 'k' });
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/payment/wait?externalLinkId=ext%201&key=k',
+        method: 'GET',
+      });
+    });
+
+    it('omits parameters that were not set', async () => {
+      const mockHttp = createMockHttpClient({});
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.waitForPayment({ linkId: '7' });
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/payment/wait?linkId=7',
+        method: 'GET',
+      });
+    });
+  });
+
+  describe('confirmPayment', () => {
+    it('confirms via PUT', async () => {
+      const mockHttp = createMockHttpClient({});
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.confirmPayment({ externalPaymentId: 'p1', key: 'k' });
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/payment/confirm?externalPaymentId=p1&key=k',
+        method: 'PUT',
+      });
+    });
+  });
+
+  describe('getHistory', () => {
+    it('sends statuses as a comma separated list and dates in ISO form', async () => {
+      const mockHttp = createMockHttpClient([]);
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.getHistory({
+        externalLinkId: 'ext1',
+        status: [PaymentLinkPaymentStatus.PENDING, PaymentLinkPaymentStatus.COMPLETED],
+        from: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      expect(mockHttp.request).toHaveBeenCalledWith({
+        url: 'paymentLink/history?externalLinkId=ext1&status=Pending,Completed&from=2026-01-01T00%3A00%3A00.000Z',
+        method: 'GET',
+      });
+    });
+
+    it('sends no query at all for an empty filter', async () => {
+      const mockHttp = createMockHttpClient([]);
+      const api = new PaymentLinksApi(mockHttp);
+
+      await api.getHistory({});
+
+      expect(mockHttp.request).toHaveBeenCalledWith({ url: 'paymentLink/history', method: 'GET' });
+    });
+  });
+});
+
+describe('hasPaymentQuote', () => {
+  it('is true for a quoted pay request', () => {
+    const response: PaymentLinkPayResponse = {
+      ...requestBase,
+      tag: 'payRequest',
+      callback: 'https://example.com/callback',
+      metadata: '[]',
+      minSendable: 1,
+      maxSendable: 2,
+      quote: { id: 'q1', expiration: new Date(), payment: 'pay1' },
+      requestedAmount: { asset: 'CHF', amount: 1 },
+    };
+
+    expect(hasPaymentQuote(response)).toBe(true);
+  });
+
+  it('is false for an idle terminal response', () => {
+    const response: PaymentLinkPayResponse = { ...requestBase, error: 'No pending payment', statusCode: 404 };
+
+    expect(hasPaymentQuote(response)).toBe(false);
+  });
+});

--- a/packages/core/src/client/PaymentLinksApi.ts
+++ b/packages/core/src/client/PaymentLinksApi.ts
@@ -5,10 +5,15 @@ import {
   UpdatePaymentLink,
   AssignPaymentLink,
   CreatePaymentLinkPayment,
+  PaymentLinkHistory,
+  PaymentLinkHistoryQuery,
+  PaymentLinkPaymentQuery,
   PaymentLinkRecipient,
   PaymentLinkConfig,
   UpdatePaymentLinkConfig,
   PaymentLinkPos,
+  PaymentStandard,
+  PaymentStandardType,
 } from '../definitions/route';
 import { CustomFile } from '../definitions/file';
 import { Utils } from '../utils';
@@ -74,5 +79,40 @@ export class PaymentLinksApi {
   async createPos(params: Record<string, string>): Promise<PaymentLinkPos> {
     const query = Utils.buildQuery(params);
     return this.http.request<PaymentLinkPos>({ url: `${PaymentLinksUrl.pos}${query}`, method: 'PUT' });
+  }
+
+  /** The payment standards the API supports. Public - no session needed. */
+  async getStandards(): Promise<PaymentStandard[]> {
+    return this.http.request<PaymentStandard[]>({ url: PaymentLinksUrl.standard, method: 'GET', token: false });
+  }
+
+  async getStandard(id: PaymentStandardType): Promise<PaymentStandard> {
+    return this.http.request<PaymentStandard>({
+      url: PaymentLinksUrl.standardById(id),
+      method: 'GET',
+      token: false,
+    });
+  }
+
+  /**
+   * Long-polls until the payment reaches a final state, then returns the link with that payment.
+   *
+   * The request stays open for as long as the API keeps it open, and it resolves on a timeout as
+   * well - read the returned status instead of assuming the payment moved.
+   */
+  async waitForPayment(params: PaymentLinkPaymentQuery): Promise<PaymentLink> {
+    const query = Utils.buildQuery({ ...params });
+    return this.http.request<PaymentLink>({ url: `${PaymentLinksUrl.paymentWait}${query}`, method: 'GET' });
+  }
+
+  async confirmPayment(params: PaymentLinkPaymentQuery): Promise<PaymentLink> {
+    const query = Utils.buildQuery({ ...params });
+    return this.http.request<PaymentLink>({ url: `${PaymentLinksUrl.paymentConfirm}${query}`, method: 'PUT' });
+  }
+
+  /** Payments of a link within a period. Without `status` the API returns completed payments only. */
+  async getHistory(params: PaymentLinkHistoryQuery): Promise<PaymentLinkHistory[]> {
+    const query = Utils.buildQuery({ ...params });
+    return this.http.request<PaymentLinkHistory[]>({ url: `${PaymentLinksUrl.history}${query}`, method: 'GET' });
   }
 }

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -115,6 +115,8 @@ export {
   PaymentQuoteStatus,
   MinCompletionStatus,
   PaymentLinkBlockchain,
+  C2BPaymentMethod,
+  hasPaymentQuote,
 } from './route';
 export type {
   MinAmount,
@@ -136,6 +138,19 @@ export type {
   UpdatePaymentLink,
   AssignPaymentLink,
   PaymentLinkPos,
+  PaymentStandard,
+  TransferMethod,
+  TransferAmount,
+  PaymentAmount,
+  PaymentQuote,
+  PaymentLinkRequestBase,
+  PaymentLinkPayRequest,
+  PaymentLinkPayTerminal,
+  PaymentLinkPayResponse,
+  PaymentLinkHistory,
+  PaymentLinkHistoryPayment,
+  PaymentLinkPaymentQuery,
+  PaymentLinkHistoryQuery,
 } from './route';
 export { SellUrl } from './sell';
 export type { Eip5792Call, Eip5792Data, UnsignedTx, Sell, Beneficiary, SellPaymentInfo, ConfirmSellData } from './sell';

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -116,6 +116,7 @@ export {
   MinCompletionStatus,
   PaymentLinkBlockchain,
   C2BPaymentMethod,
+  ManualPaymentMethod,
   hasPaymentQuote,
 } from './route';
 export type {

--- a/packages/core/src/definitions/route.ts
+++ b/packages/core/src/definitions/route.ts
@@ -1,6 +1,7 @@
 import { Asset } from './asset';
 import { Blockchain } from './blockchain';
 import { Fiat } from './fiat';
+import { GoodsCategory, GoodsType, MerchantCategory, StoreType } from './kyc';
 
 export const PaymentRoutesUrl = { get: 'route' };
 export const PaymentLinksUrl = {
@@ -149,6 +150,7 @@ export interface PaymentLink {
   routeId: string;
   externalId?: string;
   label?: string;
+  webhookUrl?: string;
   recipient?: PaymentLinkRecipient;
   status: PaymentLinkStatus;
   mode: PaymentLinkMode;
@@ -156,6 +158,7 @@ export interface PaymentLink {
   config?: PaymentLinkConfig;
   url: string;
   lnurl: string;
+  frontendUrl: string;
 }
 
 export interface PaymentLinkRecipient {
@@ -164,6 +167,11 @@ export interface PaymentLinkRecipient {
   phone?: string;
   mail?: string;
   website?: string;
+  registrationNumber?: string;
+  storeType?: StoreType;
+  merchantCategory?: MerchantCategory;
+  goodsType?: GoodsType;
+  goodsCategory?: GoodsCategory;
 }
 
 export interface PaymentLinkRecipientAddress {
@@ -250,7 +258,12 @@ export enum C2BPaymentMethod {
   KUCOIN_PAY = 'KucoinPay',
 }
 
-export type TransferMethod = Blockchain | C2BPaymentMethod;
+/** Methods that are settled by hand and are not blockchains of their own. */
+export enum ManualPaymentMethod {
+  TAPROOT_ASSET = 'TaprootAsset',
+}
+
+export type TransferMethod = Blockchain | C2BPaymentMethod | ManualPaymentMethod;
 
 export interface PaymentAmount {
   asset: string;
@@ -307,9 +320,9 @@ export interface PaymentLinkPayRequest extends PaymentLinkRequestBase {
  * usual, and the error fields say why nothing is payable.
  */
 export interface PaymentLinkPayTerminal extends PaymentLinkRequestBase {
-  error?: string;
-  message?: string;
-  statusCode?: number;
+  error: string;
+  message: string;
+  statusCode: number;
 }
 
 export type PaymentLinkPayResponse = PaymentLinkPayRequest | PaymentLinkPayTerminal;
@@ -333,6 +346,7 @@ export interface PaymentLinkHistoryPayment {
   isConfirmed: boolean;
   url: string;
   lnurl: string;
+  frontendUrl: string;
 }
 
 /** A payment link with its payments, as served by `paymentLink/history`. Carries no single `payment`. */
@@ -348,11 +362,9 @@ export interface PaymentLinkPaymentQuery {
   externalPaymentId?: string;
   /** Payment link access key, for terminals that hold no session. */
   key?: string;
-  route?: string;
 }
 
 export interface PaymentLinkHistoryQuery {
-  linkId?: string;
   externalLinkId?: string;
   key?: string;
   /** Defaults to completed payments only when omitted. */

--- a/packages/core/src/definitions/route.ts
+++ b/packages/core/src/definitions/route.ts
@@ -9,6 +9,11 @@ export const PaymentLinksUrl = {
   update: 'paymentLink',
   assign: 'paymentLink/assign',
   payment: 'paymentLink/payment',
+  paymentWait: 'paymentLink/payment/wait',
+  paymentConfirm: 'paymentLink/payment/confirm',
+  history: 'paymentLink/history',
+  standard: 'paymentLink/standard',
+  standardById: (id: PaymentStandardType) => `paymentLink/standard/${id}`,
   userPaymentLinksConfig: 'paymentLink/config',
   recipient: (route: string) => `paymentLink/recipient?id=${route}`,
   stickers: 'paymentLink/stickers',
@@ -226,4 +231,134 @@ export interface AssignPaymentLink {
 
 export interface PaymentLinkPos {
   url: string;
+}
+
+// --- PAY FLOW --- //
+
+/** Descriptor of a payment standard, as served by `paymentLink/standard`. */
+export interface PaymentStandard {
+  id: PaymentStandardType;
+  label: string;
+  description: string;
+  paymentIdentifierLabel?: string;
+  blockchain?: Blockchain;
+}
+
+/** Customer-to-business payment providers. Not blockchains, but usable as a transfer method. */
+export enum C2BPaymentMethod {
+  BINANCE_PAY = 'BinancePay',
+  KUCOIN_PAY = 'KucoinPay',
+}
+
+export type TransferMethod = Blockchain | C2BPaymentMethod;
+
+export interface PaymentAmount {
+  asset: string;
+  /** Absent while no amount has been requested yet. */
+  amount?: number;
+}
+
+export interface TransferAmount {
+  method: TransferMethod;
+  minFee: number;
+  assets: PaymentAmount[];
+  /** False when the method is currently not payable, e.g. for a missing balance. */
+  available: boolean;
+}
+
+export interface PaymentQuote {
+  id: string;
+  expiration: Date;
+  payment: string;
+}
+
+/**
+ * Common part of every pay request response. A response either carries a quote
+ * (`PaymentLinkPayRequest`) or an error (`PaymentLinkPayTerminal`); use `hasPaymentQuote` to tell
+ * them apart.
+ */
+export interface PaymentLinkRequestBase {
+  id: string;
+  externalId?: string;
+  displayName: string;
+  standard: PaymentStandardType;
+  possibleStandards: PaymentStandardType[];
+  displayQr: boolean;
+  recipient: PaymentLinkRecipient;
+  mode: PaymentLinkMode;
+  route?: string;
+  currency?: string;
+  transferAmounts: TransferAmount[];
+}
+
+/** A payable request: a payment is active and quoted. */
+export interface PaymentLinkPayRequest extends PaymentLinkRequestBase {
+  tag: string;
+  callback: string;
+  metadata: string;
+  minSendable: number;
+  maxSendable: number;
+  quote: PaymentQuote;
+  requestedAmount: PaymentAmount;
+}
+
+/**
+ * A request without an active payment, e.g. an idle terminal. The link itself is described as
+ * usual, and the error fields say why nothing is payable.
+ */
+export interface PaymentLinkPayTerminal extends PaymentLinkRequestBase {
+  error?: string;
+  message?: string;
+  statusCode?: number;
+}
+
+export type PaymentLinkPayResponse = PaymentLinkPayRequest | PaymentLinkPayTerminal;
+
+/** Narrows a pay request response to the quoted variant. */
+export function hasPaymentQuote(response: PaymentLinkPayResponse): response is PaymentLinkPayRequest {
+  return 'quote' in response;
+}
+
+export interface PaymentLinkHistoryPayment {
+  id: number;
+  externalId?: string;
+  note?: string;
+  status: PaymentLinkPaymentStatus;
+  amount: number;
+  currency: string;
+  mode: PaymentLinkPaymentMode;
+  date: Date;
+  expiryDate: Date;
+  txCount: number;
+  isConfirmed: boolean;
+  url: string;
+  lnurl: string;
+}
+
+/** A payment link with its payments, as served by `paymentLink/history`. Carries no single `payment`. */
+export interface PaymentLinkHistory extends Omit<PaymentLink, 'payment'> {
+  payments: PaymentLinkHistoryPayment[];
+  totalCompletedAmount: number;
+}
+
+/** Identifies a payment link, or a payment on it. The API needs at least one of these. */
+export interface PaymentLinkPaymentQuery {
+  linkId?: string;
+  externalLinkId?: string;
+  externalPaymentId?: string;
+  /** Payment link access key, for terminals that hold no session. */
+  key?: string;
+  route?: string;
+}
+
+export interface PaymentLinkHistoryQuery {
+  linkId?: string;
+  externalLinkId?: string;
+  key?: string;
+  /** Defaults to completed payments only when omitted. */
+  status?: PaymentLinkPaymentStatus[];
+  /** Defaults to the first day of the current month when omitted. */
+  from?: Date;
+  /** Defaults to the last day of the current month when omitted. */
+  to?: Date;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,8 @@ export {
   PaymentQuoteStatus,
   MinCompletionStatus,
   PaymentLinkBlockchain,
+  C2BPaymentMethod,
+  hasPaymentQuote,
   // Sell
   SellUrl,
   // Settings
@@ -216,6 +218,19 @@ export type {
   UpdatePaymentLink,
   AssignPaymentLink,
   PaymentLinkPos,
+  PaymentStandard,
+  TransferMethod,
+  TransferAmount,
+  PaymentAmount,
+  PaymentQuote,
+  PaymentLinkRequestBase,
+  PaymentLinkPayRequest,
+  PaymentLinkPayTerminal,
+  PaymentLinkPayResponse,
+  PaymentLinkHistory,
+  PaymentLinkHistoryPayment,
+  PaymentLinkPaymentQuery,
+  PaymentLinkHistoryQuery,
   // Sell
   Eip5792Call,
   Eip5792Data,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export {
   MinCompletionStatus,
   PaymentLinkBlockchain,
   C2BPaymentMethod,
+  ManualPaymentMethod,
   hasPaymentQuote,
   // Sell
   SellUrl,

--- a/packages/react/src/definitions/route.ts
+++ b/packages/react/src/definitions/route.ts
@@ -10,6 +10,7 @@ export {
   MinCompletionStatus,
   PaymentLinkBlockchain,
   C2BPaymentMethod,
+  ManualPaymentMethod,
   hasPaymentQuote,
 } from '@dfx.swiss/core';
 

--- a/packages/react/src/definitions/route.ts
+++ b/packages/react/src/definitions/route.ts
@@ -9,6 +9,8 @@ export {
   PaymentQuoteStatus,
   MinCompletionStatus,
   PaymentLinkBlockchain,
+  C2BPaymentMethod,
+  hasPaymentQuote,
 } from '@dfx.swiss/core';
 
 export type {
@@ -31,4 +33,17 @@ export type {
   UpdatePaymentLink,
   AssignPaymentLink,
   PaymentLinkPos,
+  PaymentStandard,
+  TransferMethod,
+  TransferAmount,
+  PaymentAmount,
+  PaymentQuote,
+  PaymentLinkRequestBase,
+  PaymentLinkPayRequest,
+  PaymentLinkPayTerminal,
+  PaymentLinkPayResponse,
+  PaymentLinkHistory,
+  PaymentLinkHistoryPayment,
+  PaymentLinkPaymentQuery,
+  PaymentLinkHistoryQuery,
 } from '@dfx.swiss/core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -88,6 +88,21 @@ export {
   PaymentLinkPos,
   PaymentRoutesUrl,
   PaymentLinksUrl,
+  PaymentStandard,
+  C2BPaymentMethod,
+  TransferMethod,
+  TransferAmount,
+  PaymentAmount,
+  PaymentQuote,
+  PaymentLinkRequestBase,
+  PaymentLinkPayRequest,
+  PaymentLinkPayTerminal,
+  PaymentLinkPayResponse,
+  PaymentLinkHistory,
+  PaymentLinkHistoryPayment,
+  PaymentLinkPaymentQuery,
+  PaymentLinkHistoryQuery,
+  hasPaymentQuote,
 } from './definitions/route';
 export { InfoBanner, SettingsUrl } from './definitions/settings';
 export { PriceStep } from './definitions/price-step';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -90,6 +90,7 @@ export {
   PaymentLinksUrl,
   PaymentStandard,
   C2BPaymentMethod,
+  ManualPaymentMethod,
   TransferMethod,
   TransferAmount,
   PaymentAmount,


### PR DESCRIPTION
Step 3 of #198: move the payment link **pay-flow** contract into the packages. CRUD was already
covered; this adds the part a paying terminal or wallet needs.

## Changes

`@dfx.swiss/core` (`definitions/route.ts`, `PaymentLinksApi`)

- URLs: `paymentLink/standard`, `paymentLink/standard/:id`, `paymentLink/payment/wait`,
  `paymentLink/payment/confirm`, `paymentLink/history`
- Types: `PaymentStandard`, `C2BPaymentMethod`, `TransferMethod`, `TransferAmount`, `PaymentAmount`,
  `PaymentQuote`, `PaymentLinkRequestBase`, `PaymentLinkPayRequest`, `PaymentLinkPayTerminal`,
  `PaymentLinkPayResponse`, `PaymentLinkHistory`, `PaymentLinkHistoryPayment`, plus the
  `PaymentLinkPaymentQuery` / `PaymentLinkHistoryQuery` parameter shapes
- `hasPaymentQuote()` type guard
- Client: `getStandards`, `getStandard`, `waitForPayment`, `confirmPayment`, `getHistory`

`@dfx.swiss/react` re-exports all of it.

Tests cover every new client method, the query building (comma-separated statuses, ISO dates,
omitted parameters) and both branches of the type guard.

## What the API actually says

The issue asked to verify the endpoints before freezing them. Doing that turned up four places
where a locally modelled version of this contract does not match the API:

1. **A history entry is not a pay request.** `paymentLink/history` returns payment links (id,
   routeId, url, lnurl, status, recipient, config …) each with their `payments[]` and
   `totalCompletedAmount`. It has no `tag`, `callback`, `quote`, `minSendable`/`maxSendable` and no
   `requestedAmount`. `PaymentLinkHistory` is modelled on the payment link, with `payment` omitted —
   the history carries the plural `payments` instead, never the singular one.
2. **A history payment has a numeric id** and carries more than id/status/amount/currency/date: also
   `note`, `mode`, `expiryDate`, `txCount`, `isConfirmed`, `url` and `lnurl`.
3. **`paymentLink/payment/wait` returns the whole payment link**, not a bare `{ status }`. The status
   lives at `payment.status`. (The bare status shape belongs to the LNURL wait endpoint, which is a
   different call.)
4. **`route` and `currency` are optional** on a pay request, and `available` is always present on a
   transfer amount.

`paymentLink/standard` does exist — it is served by its own controller rather than the payment link
controller, which is why it is easy to miss.

## Scope

- `recipient` reuses the existing `PaymentLinkRecipient` instead of introducing a second recipient
  type. It is the same object; a separate one would only differ by declaring the address fields as
  required, which the API does not guarantee.
- **No React hook.** The pay flow is a stateful polling flow whose loop, timers and merchant session
  handling belong to the consumer. The parts worth sharing are the wire types and the URL and query
  building, and those are now here.
- **Not moved:** POS UI orchestration, wallet/MetaMask handling, polling timers, merchant session
  storage, and the UI-only "no payment" pseudo status.
- The existing `PaymentLink.id` / `routeId` are typed as `string` while the API returns numbers.
  That predates this change and is left alone; `PaymentLinkHistory` inherits it rather than
  contradicting its own base type.

Version fields, changelogs and lockfile pins are untouched, per CONTRIBUTING.

---

## Corrections from review

Reviewing the frozen contract against the API turned up seven more differences, all fixed here:

- `PaymentLinkHistoryQuery.linkId` is gone. The history endpoint never reads it — a caller who passed
  it would silently get the account's whole history instead of one link's.
- `PaymentLinkPaymentQuery.route` is gone. Wait and confirm do not read it; only create and cancel do,
  and those are not wrapped here.
- `PaymentLinkHistoryPayment` and `PaymentLink` gained `frontendUrl`, which the API always sends;
  `PaymentLink` also gained the `webhookUrl` it returns. This reaches `waitForPayment`,
  `confirmPayment` and every history entry.
- `PaymentLinkRecipient` gained the five merchant fields the API carries in these responses
  (`registrationNumber`, `storeType`, `merchantCategory`, `goodsType`, `goodsCategory`).
- `TransferMethod` now covers the manually settled methods via `ManualPaymentMethod`. The API appends
  `TaprootAsset` to every transfer amount list, and that value is in no blockchain enum — the old
  union rejected a value that arrives on every single response.
- `PaymentLinkPayTerminal.error`, `.message` and `.statusCode` are required. They always arrive
  together; declaring them optional invited a null check that can never fire.

`PaymentLink` gaining a required `frontendUrl` is worth calling out for downstream consumers: reading
code is unaffected, but code that builds a `PaymentLink` literal (test fixtures, mocks) has to add the
field.
